### PR TITLE
Use `std::multiset` for `Scope` memory map

### DIFF
--- a/Fleece/Core/Doc.cc
+++ b/Fleece/Core/Doc.cc
@@ -55,6 +55,7 @@ namespace fleece { namespace impl {
     static size_t sMemoryMapTombstones = 0;
 
     // Must be called under sMutext and assumes sMemoryMap is initialized.
+    [[maybe_unused]]
     static size_t memEntryCount() {
         return sMemoryMap->size() - sMemoryMapTombstones;
     }
@@ -200,7 +201,7 @@ namespace fleece { namespace impl {
 #endif
 
             lock_guard<mutex> lock(sMutex);
-            Log("Unregister (%p ... %p) --> Scope %p, sk=%p   [Now %zu]",
+            Log("Unregister (%p ... %p) --> Scope %p, sk=%p [Now %zu]",
                 _data.buf, _data.end(), this, _sk.get(), memEntryCount()-1);
             memEntry entry = {_data.end(), this};
             auto iter = sMemoryMap->lower_bound(entry);

--- a/Fleece/Core/Doc.cc
+++ b/Fleece/Core/Doc.cc
@@ -48,7 +48,7 @@ namespace fleece { namespace impl {
 
     static memoryMap *sMemoryMap;
 
-    // The maximum number tombstones that will be created in sMemoryMap.
+    // The maximum number of tombstones that will be created in sMemoryMap.
     // While the number of registered Scopes is below this value, new Scopes can generally be
     // registered without heap allocation.
     static const size_t kMemoryMapMaxTombstones = 25;

--- a/Tests/ValueTests.cc
+++ b/Tests/ValueTests.cc
@@ -218,4 +218,18 @@ namespace fleece {
         retain(root);
         release(root);
     }
+
+    TEST_CASE("Recreate Doc from same data", "[Doc]") {
+        alloc_slice data( readTestFile("1person.fleece") );
+        Retained<Doc> doc = new Doc(data, Doc::kUntrusted);
+        doc = nullptr;
+        doc = new Doc(data, Doc::kUntrusted);
+    }
+
+    TEST_CASE("Many Docs", "[Doc]") {
+        std::vector<Retained<Doc>> docs;
+        for (int i = 0; i < 100; i++) {
+            docs.push_back(Doc::fromJSON("[]"));
+        }
+    }
 }


### PR DESCRIPTION
This PR changes the container which stores `Scope` `memEntry`s from a vector to a multiset to improve performance for registering and unregistering `Scope`s.

The complexity of finding `memEntry`'s in a multiset is the same as for a vector (both logarithmic). Insertion and removal, on the other hand, is linear for vectors and logarithmic for multisets.

Note that multisets maintain insertion order for elements that compare as equal and are therefore equivalent to the previously used vector.

[This issue](https://github.com/couchbase/couchbase-lite-C/issues/285) contains more information on the motivation for this change.