### PR TITLE
fix some warnings about "cast increases required alignment"

### DIFF
--- a/Fleece/Core/Pointer.hh
+++ b/Fleece/Core/Pointer.hh
@@ -13,6 +13,7 @@
 #pragma once
 #include "Value.hh"
 #include "betterassert.hh"
+#include <cstring>
 
 namespace fleece { namespace impl { namespace internal {
     using namespace fleece::impl;
@@ -71,10 +72,18 @@ namespace fleece { namespace impl { namespace internal {
 
         const Value* derefExtern(bool wide, const Value *dst) const noexcept;
 
-        void setNarrowBytes(uint16_t b)             {*(uint16_t*)_byte = b;}
-        void setWideBytes(uint32_t b)               {*(uint32_t*)_byte = b;}
-        uint16_t narrowBytes() const FLPURE                {return *(uint16_t*)_byte;}
-        uint32_t wideBytes() const FLPURE                  {return *(uint32_t*)_byte;}
+        void setNarrowBytes(uint16_t b) { std::memcpy(_byte, &b, sizeof(b)); }
+        void setWideBytes(uint32_t b) { std::memcpy(_byte, &b, sizeof(b)); }
+        uint16_t narrowBytes() const FLPURE {
+          uint16_t ret;
+          std::memcpy(&ret, _byte, sizeof(ret));
+          return ret;
+        }
+        uint32_t wideBytes() const FLPURE {
+          uint32_t ret;
+          std::memcpy(&ret, _byte, sizeof(ret));
+          return ret;
+        }
     };
 
 

--- a/Fleece/Support/ConcurrentMap.hh
+++ b/Fleece/Support/ConcurrentMap.hh
@@ -14,6 +14,7 @@
 #include "ConcurrentArena.hh"
 #include "fleece/slice.hh"
 #include <atomic>
+#include <cstdint>
 #include <memory>
 
 namespace fleece {
@@ -84,7 +85,7 @@ namespace fleece {
 
     private:
         // Hash table entry (32 bits).
-        struct Entry {
+        struct alignas(uint32_t) Entry {
             uint16_t keyOffset;     // offset of key from _keysOffset, or 0 if empty, 1 if deleted
             uint16_t value;         // value associated with key
 


### PR DESCRIPTION
Fix warnings that produces clang with "-Wcast-align" flags:

```
cast from 'uint8_t *' (aka 'unsigned char *') to 'uint16_t *' (aka 'unsigned short *') increases required alignment from 1 to 2 [-Wcast-align]
ast from 'uint8_t *' (aka 'unsigned char *') to 'uint32_t *' (aka 'unsigned int *') increases required alignment from 1 to 4 [-Wcast-align]
warning: cast from 'fleece::ConcurrentMap::Entry *' to 'uint32_t *' (aka 'unsigned int *') increases required alignment from 2 to 4 [-Wcast-align]
```

The result of cast from pointer with one align to pointer with another align is unspecified
in C++ and undefined behavior in C. So I think it worth to fix,
plus it should be zero cost, because of `memcpy` with fixed size inlined by all modern C++ compilers.

Not fixed:
```
FLSlice.cc:144:16: warning: cast from 'uint8_t *' (aka 'unsigned char *') to 'fleece::sharedBuffer *' increases required alignment from 1 to 4 [-Wcast-align]
        return (sharedBuffer*)((uint8_t*)buf  - offsetof(sharedBuffer, _buf));
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

and 
```
Array.cc:68:21: warning: cast from 'const fleece::impl::Value *' to 'fleece::impl::ValueSlot *' increases required alignment from 1 to 8 [-Wcast-align]
            return ((ValueSlot*)v)->asValue();
                    ^~~~~~~~~~~~~
```