### PR TITLE
Fix missing FLEECE_PUBLIC tagging

### DIFF
--- a/API/fleece/CompilerSupport.h
+++ b/API/fleece/CompilerSupport.h
@@ -225,6 +225,27 @@
     #define WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) 0
 #endif
 
+// On Windows, FLEECE_PUBLIC marks symbols as being exported from the shared library.
+// However, this is not the whole list of things that are exported.  The API methods
+// are exported using a definition list, but it is not possible to correctly include
+// initialized global variables, so those need to be marked (both in the header and
+// implementation) with FLEECE_PUBLIC.  See kFLNullValue below and in Fleece.cc
+// for an example.
+#if defined(_MSC_VER)
+#ifdef FLEECE_EXPORTS
+#define FLEECE_PUBLIC __declspec(dllexport)
+#else
+#define FLEECE_PUBLIC __declspec(dllimport)
+#endif
+#else
+#define FLEECE_PUBLIC __attribute__((visibility("default")))
+#endif
+
+#ifdef __cplusplus
+    #define FLAPI noexcept
+#else
+    #define FLAPI
+#endif
 
 #else // _FLEECE_COMPILER_SUPPORT_H
 #warn "Compiler is not honoring #pragma once"

--- a/API/fleece/FLBase.h
+++ b/API/fleece/FLBase.h
@@ -17,22 +17,6 @@
 #include "CompilerSupport.h"
 #include "FLSlice.h"
 
-// On Windows, FLEECE_PUBLIC marks symbols as being exported from the shared library.
-// However, this is not the whole list of things that are exported.  The API methods
-// are exported using a definition list, but it is not possible to correctly include
-// initialized global variables, so those need to be marked (both in the header and
-// implementation) with FLEECE_PUBLIC.  See kFLNullValue below and in Fleece.cc
-// for an example.
-#if defined(_MSC_VER)
-#ifdef FLEECE_EXPORTS
-#define FLEECE_PUBLIC __declspec(dllexport)
-#else
-#define FLEECE_PUBLIC __declspec(dllimport)
-#endif
-#else
-#define FLEECE_PUBLIC __attribute__((visibility("default")))
-#endif
-
 FL_ASSUME_NONNULL_BEGIN
 
 #ifdef __cplusplus

--- a/API/fleece/FLExpert.h
+++ b/API/fleece/FLExpert.h
@@ -257,7 +257,7 @@ extern "C" {
         value written. You can continue writing, and the final output returned by \ref FLEncoder_Finish will
         consist of everything after this point. That second part can be used in the future by loading it
         as an `FLDoc` with the first part as its `extern` reference. */
-    FLSliceResult FLEncoder_Snip(FLEncoder) FLAPI;
+    FLEECE_PUBLIC FLSliceResult FLEncoder_Snip(FLEncoder) FLAPI;
 
     /** Finishes encoding the current item, and returns its offset in the output data. */
     FLEECE_PUBLIC size_t FLEncoder_FinishItem(FLEncoder) FLAPI;

--- a/API/fleece/FLSlice.h
+++ b/API/fleece/FLSlice.h
@@ -25,10 +25,7 @@
 
 #ifdef __cplusplus
     #include <string>
-    #define FLAPI noexcept
     namespace fleece { struct alloc_slice; }
-#else
-    #define FLAPI
 #endif
 
 
@@ -140,14 +137,14 @@ static inline FLSlice FLStr(const char* FL_NULLABLE str) FLAPI {
 
 
 /** Equality test of two slices. */
-bool FLSlice_Equal(FLSlice a, FLSlice b) FLAPI FLPURE;
+FLEECE_PUBLIC bool FLSlice_Equal(FLSlice a, FLSlice b) FLAPI FLPURE;
 
 /** Lexicographic comparison of two slices; basically like memcmp(), but taking into account
     differences in length. */
-int FLSlice_Compare(FLSlice, FLSlice) FLAPI FLPURE;
+FLEECE_PUBLIC int FLSlice_Compare(FLSlice, FLSlice) FLAPI FLPURE;
 
 /** Computes a 32-bit hash of a slice's data, suitable for use in hash tables. */
-uint32_t FLSlice_Hash(FLSlice s) FLAPI FLPURE;
+FLEECE_PUBLIC uint32_t FLSlice_Hash(FLSlice s) FLAPI FLPURE;
 
 /** Copies a slice to a buffer, adding a trailing zero byte to make it a valid C string.
     If there is not enough capacity the slice will be truncated, but the trailing zero byte is
@@ -156,13 +153,13 @@ uint32_t FLSlice_Hash(FLSlice s) FLAPI FLPURE;
     @param buffer  Where to copy the bytes. At least `capacity` bytes must be available.
     @param capacity  The maximum number of bytes to copy (including the trailing 0.)
     @return  True if the entire slice was copied, false if it was truncated. */
-bool FLSlice_ToCString(FLSlice s, char* buffer, size_t capacity) FLAPI;
+FLEECE_PUBLIC bool FLSlice_ToCString(FLSlice s, char* buffer, size_t capacity) FLAPI;
 
 /** Allocates an FLSliceResult of the given size, without initializing the buffer. */
-FLSliceResult FLSliceResult_New(size_t) FLAPI;
+FLEECE_PUBLIC FLSliceResult FLSliceResult_New(size_t) FLAPI;
 
 /** Allocates an FLSliceResult, copying the given slice. */
-FLSliceResult FLSlice_Copy(FLSlice) FLAPI;
+FLEECE_PUBLIC FLSliceResult FLSlice_Copy(FLSlice) FLAPI;
 
 
 /** Allocates an FLSliceResult, copying `size` bytes starting at `buf`. */
@@ -172,8 +169,8 @@ static inline FLSliceResult FLSliceResult_CreateWith(const void* FL_NULLABLE byt
 }
 
 
-void _FLBuf_Retain(const void* FL_NULLABLE) FLAPI;   // internal; do not call
-void _FLBuf_Release(const void* FL_NULLABLE) FLAPI;  // internal; do not call
+FLEECE_PUBLIC void _FLBuf_Retain(const void* FL_NULLABLE) FLAPI;   // internal; do not call
+FLEECE_PUBLIC void _FLBuf_Release(const void* FL_NULLABLE) FLAPI;  // internal; do not call
 
 /** Increments the ref-count of a FLSliceResult. */
 static inline FLSliceResult FLSliceResult_Retain(FLSliceResult s) FLAPI {
@@ -197,7 +194,7 @@ static inline FLSlice FLSliceResult_AsSlice(FLSliceResult sr) {
 /** Writes zeroes to `size` bytes of memory starting at `dst`.
     Unlike a call to `memset`, these writes cannot be optimized away by the compiler.
     This is useful for securely removing traces of passwords or encryption keys. */
-void FL_WipeMemory(void *dst, size_t size) FLAPI;
+FLEECE_PUBLIC void FL_WipeMemory(void *dst, size_t size) FLAPI;
 
 
 /** @} */


### PR DESCRIPTION
* Moved FLEECE_PUBLIC (from FLBase.h) and FLAPI (from FLSlice.h) to CompilerSupport.h to avoid circular includes.

* Fixed missing FLEECE_PUBLIC tagging