### PR TITLE
Added FLJSONEncoder_NextDocument()

### DIFF
--- a/API/fleece/FLExpert.h
+++ b/API/fleece/FLExpert.h
@@ -262,6 +262,12 @@ extern "C" {
     /** Finishes encoding the current item, and returns its offset in the output data. */
     FLEECE_PUBLIC size_t FLEncoder_FinishItem(FLEncoder) FLAPI;
 
+    /** In a JSON encoder, adds a newline ('\n') and prepares to start encoding another
+        top-level object. The encoder MUST be not be within an array or dict.
+        Has no effect in a Fleece encoder. */
+    FLEECE_PUBLIC void FLJSONEncoder_NextDocument(FLEncoder) FLAPI;
+
+
     /** @} */
 
 

--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -684,6 +684,10 @@ bool FLEncoder_WriteKey(FLEncoder e, FLSlice s)         FLAPI {ENCODER_TRY(e, wr
 bool FLEncoder_WriteKeyValue(FLEncoder e, FLValue key)  FLAPI {ENCODER_TRY(e, writeKey(key));}
 bool FLEncoder_EndDict(FLEncoder e)                     FLAPI {ENCODER_TRY(e, endDictionary());}
 
+void FLJSONEncoder_NextDocument(FLEncoder e) FLAPI {
+    if (!e->isFleece())
+        e->jsonEncoder->nextDocument();
+}
 
 bool FLEncoder_ConvertJSON(FLEncoder e, FLSlice json) FLAPI {
     if (!e->hasError()) {

--- a/Fleece/Support/JSONEncoder.hh
+++ b/Fleece/Support/JSONEncoder.hh
@@ -41,6 +41,9 @@ namespace fleece { namespace impl {
         /** Resets the encoder so it can be used again. */
         void reset()                            {_out.reset(); _first = true;}
 
+        /** Adds a newline between consecutive top-level values. */
+        void nextDocument()                     {_out << '\n'; _first = true;}
+
         /////// Writing data:
 
         void writeNull()                        {comma(); _out << slice("null");}


### PR DESCRIPTION
This helps generate output in the common JSON-object-per-line format. (Does it have an official name?)

I'm using this format in Connected Client for query results.