### PR TITLE
CBL-3366 : FLDoc_FromResultData leaks memory

### DIFF
--- a/API/fleece/Fleece.hh
+++ b/API/fleece/Fleece.hh
@@ -326,9 +326,8 @@ namespace fleece {
             FLSharedKeys FL_NULLABLE sk =nullptr,
             slice externDest =nullslice) noexcept
         {
-            auto sliceResult = FLSliceResult(std::move(fleeceData));
+            FLSliceResult sliceResult {fleeceData.buf, fleeceData.size};
             _doc = FLDoc_FromResultData(sliceResult, trust, sk, externDest);
-            FLSliceResult_Release(sliceResult);
         }
 
         static inline Doc fromJSON(slice_NONNULL json, FLError* FL_NULLABLE outError = nullptr);

--- a/API/fleece/Fleece.hh
+++ b/API/fleece/Fleece.hh
@@ -325,8 +325,11 @@ namespace fleece {
             FLTrust trust =kFLUntrusted,
             FLSharedKeys FL_NULLABLE sk =nullptr,
             slice externDest =nullslice) noexcept
-        :_doc(FLDoc_FromResultData(FLSliceResult(std::move(fleeceData)), trust, sk, externDest))
-        { }
+        {
+            auto sliceResult = FLSliceResult(std::move(fleeceData));
+            _doc = FLDoc_FromResultData(sliceResult, trust, sk, externDest);
+            FLSliceResult_Release(sliceResult);
+        }
 
         static inline Doc fromJSON(slice_NONNULL json, FLError* FL_NULLABLE outError = nullptr);
 

--- a/API/fleece/Fleece.hh
+++ b/API/fleece/Fleece.hh
@@ -326,6 +326,9 @@ namespace fleece {
             FLSharedKeys FL_NULLABLE sk =nullptr,
             slice externDest =nullslice) noexcept
         {
+            // We construct FLSliceResult the following way to avoid unnecessary
+            // retain. (alloc_slice::operator FLSliceResult()& will apply a retain, which,
+            // if not matched by a release, will lead to memory leak.)
             FLSliceResult sliceResult {fleeceData.buf, fleeceData.size};
             _doc = FLDoc_FromResultData(sliceResult, trust, sk, externDest);
         }

--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -786,9 +786,7 @@ FLSliceResult FLEncoder_Finish(FLEncoder e, FLError * FL_NULLABLE outError) FLAP
 
 
 FLDoc FLDoc_FromResultData(FLSliceResult data, FLTrust trust, FLSharedKeys FL_NULLABLE sk, FLSlice externData) FLAPI {
-    auto ret = retain(new Doc(alloc_slice(data), (Doc::Trust)trust, sk, externData));
-    FLSliceResult_Release(data);
-    return ret;
+    return retain(new Doc(alloc_slice(data), (Doc::Trust)trust, sk, externData));
 }
 
 FLDoc FL_NULLABLE FLDoc_FromJSON(FLSlice json, FLError* FL_NULLABLE outError) FLAPI {

--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -786,7 +786,9 @@ FLSliceResult FLEncoder_Finish(FLEncoder e, FLError * FL_NULLABLE outError) FLAP
 
 
 FLDoc FLDoc_FromResultData(FLSliceResult data, FLTrust trust, FLSharedKeys FL_NULLABLE sk, FLSlice externData) FLAPI {
-    return retain(new Doc(alloc_slice(data), (Doc::Trust)trust, sk, externData));
+    auto ret = retain(new Doc(alloc_slice(data), (Doc::Trust)trust, sk, externData));
+    FLSliceResult_Release(data);
+    return ret;
 }
 
 FLDoc FL_NULLABLE FLDoc_FromJSON(FLSlice json, FLError* FL_NULLABLE outError) FLAPI {


### PR DESCRIPTION
It uses an aurgument of FLSliceResult, but fails to release it. The leak is found by valgrind.