### PR TITLE
CBL-3686: add a new retain function, retainUnlessUnique, to RefCounted

### DIFF
--- a/API/fleece/RefCounted.hh
+++ b/API/fleece/RefCounted.hh
@@ -39,6 +39,8 @@ namespace fleece {
     private:
         template <typename T>
         friend T* retain(T*) noexcept;
+        template <typename T>
+        friend bool retainUnlessUnique(T*) noexcept;
         friend void release(const RefCounted*) noexcept;
         friend void assignRef(RefCounted* &dst, RefCounted *src) noexcept;
 
@@ -49,6 +51,7 @@ namespace fleece {
         ALWAYS_INLINE void _retain() const noexcept   { ++_refCount; }
         void _release() const noexcept;
 #endif
+        bool _retainUnlessUnique() const noexcept;
 
         static constexpr int32_t kCarefulInitialRefCount = -6666666;
         void _careful_retain() const noexcept;
@@ -72,6 +75,13 @@ namespace fleece {
         if (r) r->_retain();
         return r;
     }
+
+
+    template <typename REFCOUNTED>
+    ALWAYS_INLINE bool retainUnlessUnique(REFCOUNTED *r) noexcept {
+        return r->_retainUnlessUnique();
+    }
+
 
     /** Releases a RefCounted object. Does nothing given a null pointer.
         \warning Manual retain/release is error prone. This function is intended mostly for interfacing

--- a/Fleece/Support/RefCounted.cc
+++ b/Fleece/Support/RefCounted.cc
@@ -122,4 +122,21 @@ namespace fleece {
         if (oldRef == 1) delete this;
     }
 
+
+    // Performs retain only if _refCount is not 1, or, equivalently, greater than 1.
+    // Otherwise, returns false without changing the _refCount.
+    bool RefCounted::_retainUnlessUnique() const noexcept {
+        auto cur = _refCount.load();
+        while (cur != 1) {
+            if (cur <= 0) {
+                // throws.
+                fail(this, "retained", cur);
+            }
+            if (_refCount.compare_exchange_weak(cur, cur+1)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }


### PR DESCRIPTION
It retains the RefCounted only if the ref-count is greater than 1. Otherwise, it returns false without retaining.