### PR TITLE
CBL-3833 : Don't cache `Dict::key::_numericKey` when `SharedKeys` is in transaction (Port)

### DIFF
--- a/Fleece/Core/Dict.cc
+++ b/Fleece/Core/Dict.cc
@@ -128,7 +128,11 @@ namespace fleece { namespace impl {
                 if (_usuallyFalse(_count == 0))
                     return nullptr;
                 if (lookupSharedKey(keyToFind._rawString, sharedKeys, keyToFind._numericKey)) {
-                    keyToFind._hasNumericKey = true;
+                    // If the SharedKeys are in a transaction we don't mark the key as having a
+                    // shared key, because the transaction might be rolled back. If the found
+                    // shared key is rolled back as part of rolling back the transaction, continuing
+                    // to use it would lead to incorrect lookup results.
+                    keyToFind._hasNumericKey = !sharedKeys->isInTransaction();
                     return get(keyToFind._numericKey);
                 }
             }

--- a/Fleece/Core/SharedKeys.hh
+++ b/Fleece/Core/SharedKeys.hh
@@ -106,6 +106,8 @@ namespace fleece { namespace impl {
 
         bool isUnknownKey(int key) const FLPURE;
 
+        bool isInTransaction() const FLPURE             {return _inTransaction;}
+
         virtual bool refresh()                          {return false;}
 
         static const size_t kMaxCount = 2048;               // Max number of keys to store


### PR DESCRIPTION
Port from the master branch (https://github.com/couchbase/fleece/commit/dcaa54943e6fcf05a610476912299873b5328bf7) for 3.0.6-MR.

A transaction might be rolled back, potentially leaving an invalid shared key in a `Dict::key`.