### PR TITLE
Fixed a bug in FLEncoder_LastValueWritten, FLEncoder_Snip, FLEncoder_WriteValueAgain

### DIFF
--- a/Fleece/Core/Encoder.hh
+++ b/Fleece/Core/Encoder.hh
@@ -172,7 +172,7 @@ namespace fleece { namespace impl {
         slice baseUsed() const                  {return _baseMinUsed != 0 ? slice(_baseMinUsed, _base.end()) : slice();}
         const StringTable& strings() const      {return _strings;}
 
-        enum class PreWrittenValue : ssize_t { none = 0 };
+        enum class PreWrittenValue : ssize_t { none = INTPTR_MIN };
         PreWrittenValue lastValueWritten() const;   // Opaque reference to last thing written
         void writeValueAgain(PreWrittenValue);         // Writes pointer to an already-written value
 


### PR DESCRIPTION
The internal enum type Encoder::PreWrittenValue had a badly-chosen "none" value of 0, which could easily occur as a valid value.

This meant Encoder::lastValueWritten() would return a false negative if the last value written was the first value (at offset 0.)

This in turn meant Encoder::snip() would return nullslice in this case.

This in turn broke LiteCore's VectorRecord.

This fix shouldn't affect anything, since these API calls are only used by LiteCore's version vector code, which is still disabled.