### PR TITLE
CBL-4824: Move fixes for 3.1.2 from `next/3.1` to `release/3.1`

### DIFF
--- a/Fleece/Core/Doc.cc
+++ b/Fleece/Core/Doc.cc
@@ -177,7 +177,7 @@ namespace fleece { namespace impl {
             while (it->scope) it++;
             auto node = sMemoryMap->extract(it);
             node.value() = entry;
-            sMemoryMap->insert(move(node));
+            sMemoryMap->insert(std::move(node));
             sMemoryMapTombstones--;
         } else {
             sMemoryMap->insert(iter, entry);

--- a/Fleece/Mutable/HeapValue.cc
+++ b/Fleece/Mutable/HeapValue.cc
@@ -158,7 +158,7 @@ namespace fleece { namespace impl { namespace internal {
         } else if (v) {
             RetainedConst<Doc> doc = Doc::containing(v);
             if (_usuallyTrue(doc != nullptr))
-                fleece::retain(move(doc));
+                fleece::retain(std::move(doc));
             else if (!isHardwiredValue(v))
                 FleeceException::_throw(InvalidData,
                                         "Can't retain immutable Value %p that's not part of a Doc",

--- a/Fleece/Support/Backtrace.cc
+++ b/Fleece/Support/Backtrace.cc
@@ -396,7 +396,7 @@ namespace fleece {
     void Backtrace::installTerminateHandler(function<void(const string&)> logger) {
         static once_flag sOnce;
         call_once(sOnce, [&] {
-            static auto const sLogger = move(logger);
+            static auto const sLogger = std::move(logger);
             static terminate_handler const sOldHandler = set_terminate([] {
                 // ---- Code below gets called by C++ runtime on an uncaught exception ---
                 if (sLogger) {

--- a/Fleece/Support/ConcurrentArena.cc
+++ b/Fleece/Support/ConcurrentArena.cc
@@ -31,12 +31,12 @@ namespace fleece {
 
 
     ConcurrentArena::ConcurrentArena(ConcurrentArena &&other) {
-        *this = move(other);
+        *this = std::move(other);
     }
 
 
     ConcurrentArena& ConcurrentArena::operator=(ConcurrentArena &&other) {
-        _heap = move(other._heap);
+        _heap = std::move(other._heap);
         _heapEnd = other._heapEnd;
         _nextBlock = other._nextBlock.load();
         return *this;

--- a/Fleece/Support/ConcurrentMap.cc
+++ b/Fleece/Support/ConcurrentMap.cc
@@ -103,7 +103,7 @@ namespace fleece {
 
 
     ConcurrentMap::ConcurrentMap(ConcurrentMap &&map) {
-        *this = move(map);
+        *this = std::move(map);
     }
 
 
@@ -112,7 +112,7 @@ namespace fleece {
         _capacity = map._capacity;
         _count = map._count.load();
         _entries = map._entries;
-        _heap = move(map._heap);
+        _heap = std::move(map._heap);
         return *this;
     }
 

--- a/Xcode/xcconfigs/FleeceTest.xcconfig
+++ b/Xcode/xcconfigs/FleeceTest.xcconfig
@@ -12,7 +12,6 @@
 //  the file licenses/APL2.txt.
 //
 
-// Workaround for Catch 2 requiring C++ features not available until macOS 10.12
 MACOSX_DEPLOYMENT_TARGET            = 10.14
 
 CLANG_WARN__EXIT_TIME_DESTRUCTORS = NO

--- a/Xcode/xcconfigs/FleeceTest.xcconfig
+++ b/Xcode/xcconfigs/FleeceTest.xcconfig
@@ -13,7 +13,7 @@
 //
 
 // Workaround for Catch 2 requiring C++ features not available until macOS 10.12
-MACOSX_DEPLOYMENT_TARGET            = 10.12
+MACOSX_DEPLOYMENT_TARGET            = 10.14
 
 CLANG_WARN__EXIT_TIME_DESTRUCTORS = NO
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) _LIBCPP_DEBUG=0


### PR DESCRIPTION
Looks like Core release branch requires Fleece submodule points to matching release branch.
This is merged from master up to the point required for CBL-4824, which is the Xcode 14.3 fixes that allow Core to build.