### PR TITLE
CBL-4508: Fix a bug in FLTimestamp_ToString

### DIFF
--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -53,8 +53,7 @@ FLTimestamp FLTimestamp_Now() FLAPI {
 
 FLStringResult FLTimestamp_ToString(FLTimestamp timestamp, bool asUTC) FLAPI {
     char str[kFormattedISO8601DateMaxSize];
-    FormatISO8601Date(str, timestamp, asUTC);
-    return FLSliceResult_CreateWith(str, strlen(str));
+    return FLSlice_Copy(FormatISO8601Date(str, timestamp, asUTC));
 }
 
 

--- a/Tests/SupportTests.cc
+++ b/Tests/SupportTests.cc
@@ -10,6 +10,7 @@
 // the file licenses/APL2.txt.
 //
 
+#include "fleece/FLBase.h"
 #include "FleeceTests.hh"
 #include "FleeceImpl.hh"
 #include "ConcurrentMap.hh"
@@ -327,4 +328,19 @@ TEST_CASE("Base64 encode and decode", "[Base64]") {
         auto decoded = base64::decode(slice(encoded));
         CHECK(decoded == in);
     }
+}
+
+
+TEST_CASE("Timestamp Conversions", "[Timestamps]") {
+    FLTimestamp ts = FLTimestamp_Now();
+    bool asUTC = true;
+    SECTION("UTC") {
+        asUTC = true;
+    }
+    SECTION("Not UTC") {
+        asUTC = false;
+    }
+    FLStringResult str = FLTimestamp_ToString(ts, asUTC);
+    FLTimestamp ts2 = FLTimestamp_FromString((FLString)str);
+    CHECK(ts == ts2);
 }


### PR DESCRIPTION
Ported from CBL 4470 of Beryllium.