### PR TITLE
Three fixes needed for latest LiteCore VV work

### DIFF
--- a/API/fleece/FLExpert.h
+++ b/API/fleece/FLExpert.h
@@ -31,6 +31,12 @@ extern "C" {
     /** \defgroup Obscure  Rarely-needed or advanced functions
         @{ */
 
+    /** For use with \ref FLDoc_FromResultData. This option prevents the function from parsing the
+        data at all; you are responsible for locating the FLValues in it.
+        This is for the case where you have trusted data in a custom format that contains Fleece-
+        encoded data within it. You still need an FLDoc to access the data safely (especially to
+        retain FLValues), but it can't be parsed as-is. */
+    #define kFLTrustedDontParse FLTrust(-1)
 
     /** \name  Delta Compression
      @{

--- a/Fleece/Mutable/HeapDict.cc
+++ b/Fleece/Mutable/HeapDict.cc
@@ -20,7 +20,7 @@
 
 namespace fleece { namespace impl { namespace internal {
 
-    HeapDict::HeapDict(const Dict *d)
+    HeapDict::HeapDict(const Dict *d, CopyFlags flags)
     :HeapCollection(kDictTag)
     {
         if (d) {
@@ -30,9 +30,15 @@ namespace fleece { namespace impl { namespace internal {
                 _source = hd->_source;
                 _map = hd->_map;
                 _backingSlices = hd->_backingSlices;
+            } else if (flags & kCopyImmutables) {
+                _count = 0;
+                for (Dict::iterator i(d); i; ++i) 
+                    set(i.keyString(), i.value());
             } else {
                 _source = d;
             }
+            if (flags)
+                copyChildren(flags);
             if (_source)
                 _sharedKeys = _source->sharedKeys();
         }

--- a/Fleece/Mutable/HeapDict.hh
+++ b/Fleece/Mutable/HeapDict.hh
@@ -27,7 +27,7 @@ namespace fleece { namespace impl { namespace internal {
 
     class HeapDict : public HeapCollection {
     public:
-        HeapDict(const Dict* =nullptr);
+        HeapDict(const Dict* =nullptr, CopyFlags flags =kDefaultCopy);
 
         static MutableDict* asMutableDict(HeapDict *a)      {return (MutableDict*)asValue(a);}
         MutableDict* asMutableDict() const                  {return (MutableDict*)asValue();}

--- a/Fleece/Mutable/MutableDict.hh
+++ b/Fleece/Mutable/MutableDict.hh
@@ -22,10 +22,7 @@ namespace fleece { namespace impl {
     public:
 
         static Retained<MutableDict> newDict(const Dict *d =nullptr, CopyFlags flags =kDefaultCopy) {
-            auto hd = retained(new internal::HeapDict(d));
-            if (flags)
-                hd->copyChildren(flags);
-            return hd->asMutableDict();
+            return retained(new internal::HeapDict(d, flags))->asMutableDict();
         }
 
         Retained<MutableDict> copy(CopyFlags f =kDefaultCopy) {return newDict(this, f);}

--- a/Fleece/Support/slice_stream.hh
+++ b/Fleece/Support/slice_stream.hh
@@ -137,7 +137,10 @@ namespace fleece {
         constexpr slice_istream(const alloc_slice &s) noexcept  :slice(s) { }
         constexpr slice_istream(const void* b, size_t s) noexcept STEPOVER    :slice(b, s) {}
         constexpr slice_istream(const void* s NONNULL, const void* e NONNULL) noexcept STEPOVER
-                                                                                :slice(s, e) { }
+                                                                      :slice(s, e) { }
+        constexpr slice_istream(slice_istream&&) = default;
+        slice_istream& operator=(slice_istream&&) = default;
+
         /// The number of bytes remaining to be read.
         size_t bytesRemaining() const noexcept FLPURE           {return size;}
 
@@ -232,6 +235,6 @@ namespace fleece {
         // Pass-by-value is intentionally forbidden to make passing a `slice_istream` as a
         // parameter illegal. That's because its behavior would be wrong: reads made by the
         // callee would not be reflected in the caller. Always pass a reference, `slice_istream&`.
-        slice_istream(const slice_istream&) = default;
+        slice_istream(const slice_istream&) = delete;
     };
 }


### PR DESCRIPTION
1. Fixed a crash in Dict::mutableCopy() using kCopyImmutables
2. Make slice_istream moveable (just added default move ctor/assign)
3. Expose impl constant Trust::kDontParse in FLExpert.h