### PR TITLE
fix: bump 50 level parsing limitation to 100

### DIFF
--- a/Fleece/Core/JSONConverter.cc
+++ b/Fleece/Core/JSONConverter.cc
@@ -32,7 +32,7 @@ namespace fleece { namespace impl {
 
     JSONConverter::JSONConverter(Encoder &e) noexcept
     :_encoder(e),
-     _jsn(jsonsl_new(UINT_MAX)),      // never returns nullptr, according to source code
+     _jsn(jsonsl_new(100)),      // never returns nullptr, according to source code
      _jsonError(JSONSL_ERROR_SUCCESS),
      _errorPos(0)
     {

--- a/Fleece/Core/JSONConverter.cc
+++ b/Fleece/Core/JSONConverter.cc
@@ -32,7 +32,7 @@ namespace fleece { namespace impl {
 
     JSONConverter::JSONConverter(Encoder &e) noexcept
     :_encoder(e),
-     _jsn(jsonsl_new(50)),      // never returns nullptr, according to source code
+     _jsn(jsonsl_new(UINT_MAX)),      // never returns nullptr, according to source code
      _jsonError(JSONSL_ERROR_SUCCESS),
      _errorPos(0)
     {


### PR DESCRIPTION
~~This PR bumps the 50 level parsing limit found in the parser up to `UINT_MAX`.~~

This PR bumps the 50 level parsing limit found in the parser up to 100.