### PR TITLE
CBL-59: Fix for core

### DIFF
--- a/Fleece/Support/ParseDate.cc
+++ b/Fleece/Support/ParseDate.cc
@@ -431,10 +431,11 @@ namespace fleece {
     DateTime FromMillis(int64_t timestamp) {
         // Split out the milliseconds from the timestamp:
         time_t secs{timestamp / 1000};
-        int    millis = (int)timestamp % 1000;
+        int    millis = (int)(timestamp % 1000);
 
         struct tm  timebuf {};
         struct tm* result = gmtime_r(&secs, &timebuf);
+        if ( result == nullptr ) { return {}; }
         return {0,
                 timebuf.tm_year + 1900,
                 timebuf.tm_mon + 1,


### PR DESCRIPTION
This fixes 2 issues:
- Apparently I forgot to run some of the tests in Core, so an incorrect cast which was causing overflow is now fixed.
- Core has stricter compilation warnings and errors than Fleece, so an issue which was caught by Core's build (`result` var unused), was not caught by the Fleece PR / build.

For the second issue, this could be avoided if we make Fleece have the same warnings / error settings as Core.