### PR TITLE
Fixed crash calling DictIterator::keyString

### DIFF
--- a/Fleece/Core/Dict.cc
+++ b/Fleece/Core/Dict.cc
@@ -452,6 +452,8 @@ namespace fleece { namespace impl {
     }
 
     slice DictIterator::keyString() const noexcept {
+        if (_usuallyFalse(!_key))
+            return nullslice;
         slice keyStr = _key->asString();
         if (!keyStr && _key->isInteger()) {
             auto sk = _sharedKeys ? _sharedKeys : findSharedKeys();
@@ -463,7 +465,9 @@ namespace fleece { namespace impl {
     }
 
     key_t DictIterator::keyt() const noexcept {
-        if (_key->isInteger())
+        if (_usuallyFalse(!_key))
+            return {};
+        else if (_key->isInteger())
             return (int)_key->asInt();
         else
             return _key->asString();

--- a/Tests/ValueTests.cc
+++ b/Tests/ValueTests.cc
@@ -234,6 +234,32 @@ namespace fleece {
         }
     }
 
+    TEST_CASE("Empty FLArrayIterator", "[API]") {
+        FLDoc doc = FLDoc_FromJSON("[]"_sl, nullptr);
+        FLArray arr = FLValue_AsArray(FLDoc_GetRoot(doc));
+        REQUIRE(arr);
+        FLArrayIterator iter;
+        FLArrayIterator_Begin(arr, &iter);
+        CHECK(FLArrayIterator_GetValue(&iter) == nullptr);
+        CHECK(FLArrayIterator_GetCount(&iter) == 0);
+        // (calling FLArrayIterator_Next would be illegal)
+        FLDoc_Release(doc);
+    }
+
+    TEST_CASE("Empty FLDictIterator", "[API]") {
+        FLDoc doc = FLDoc_FromJSON("{}"_sl, nullptr);
+        FLDict arr = FLValue_AsDict(FLDoc_GetRoot(doc));
+        REQUIRE(arr);
+        FLDictIterator iter;
+        FLDictIterator_Begin(arr, &iter);
+        CHECK(FLDictIterator_GetValue(&iter) == nullptr);
+        CHECK(FLDictIterator_GetKey(&iter) == nullptr);
+        CHECK(FLDictIterator_GetKeyString(&iter) == kFLSliceNull);
+        CHECK(FLDictIterator_GetCount(&iter) == 0);
+        // (calling FLDictIterator_Next would be illegal)
+        FLDoc_Release(doc);
+    }
+
     TEST_CASE("Array Iterators") {
         FLDoc doc = nullptr;
         SECTION("Empty Array") {


### PR DESCRIPTION
If a dict iterator is at the end, calling key() or value() is safe but keyString() crashes. Let's fix that.

Also added some sanity checks of iterators on empty collections, which includes a test of this fix.