### PR TITLE
Fix loss of precision encoding some double values to JSON (#206)

### DIFF
--- a/Fleece.md
+++ b/Fleece.md
@@ -81,7 +81,8 @@ The reason for the (rare) second pointer dereference is that the true root objec
 ```
  0000iiii iiiiiiii       small integer (12-bit, signed, range ±2048)
  0001uccc iiiiiiii...    long integer (u = unsigned?; ccc = byte count - 1) LE integer follows
- 0010s--- --------...    floating point (s = 0:float, 1:double). LE float data follows.
+ 0010sx-- --------...    floating point (s = 0:32-bit, 1:64-bit). LE float data follows.
+                                If x=1, value is a `double` even if encoded as 32-bit `float`.
  0011ss-- --------       special (s = 0:null, 1:false, 2:true, 3:undefined)
  0100cccc ssssssss...    string (cccc is byte count, or if it’s 15 then count follows as varint)
  0101cccc dddddddd...    binary data (same as string)

--- a/Fleece/Core/Encoder.cc
+++ b/Fleece/Core/Encoder.cc
@@ -273,12 +273,9 @@ namespace fleece { namespace impl {
         } else
 #endif
         if (isFloatRepresentable(n)) {
-            return _writeFloat((float)n);
+            _writeFloat<float,endian::littleEndianFloat>(float(n), kFloatValue32BitDouble);
         } else {
-            endian::littleEndianDouble swapped = n;
-            auto buf = placeValue<false>(kFloatTag, 0x08, 2 + sizeof(swapped));
-            buf[1] = 0;
-            memcpy(&buf[2], &swapped, sizeof(swapped));
+            _writeFloat<double,endian::littleEndianDouble>(n, kFloatValue64BitDouble);
         }
     }
 
@@ -289,12 +286,13 @@ namespace fleece { namespace impl {
             writeInt((int32_t)n);
         else
 #endif
-            _writeFloat(n);
+            _writeFloat<float,endian::littleEndianFloat>(n, kFloatValue32BitSingle);
     }
 
-    void Encoder::_writeFloat(float n) {
-        endian::littleEndianFloat swapped = n;
-        auto buf = placeValue<false>(kFloatTag, 0, 2 + sizeof(swapped));
+    template<typename Float, typename Swapped>
+    void Encoder::_writeFloat(Float n, byte param) {
+        Swapped swapped = n;
+        auto buf = placeValue<false>(kFloatTag, param, 2 + sizeof(swapped));
         buf[1] = 0;
         memcpy(&buf[2], &swapped, sizeof(swapped));
     }

--- a/Fleece/Core/Encoder.hh
+++ b/Fleece/Core/Encoder.hh
@@ -217,7 +217,7 @@ namespace fleece { namespace impl {
         void writePointer(ssize_t pos);
         void writeSpecial(uint8_t special);
         void writeInt(uint64_t i, bool isShort, bool isUnsigned);
-        void _writeFloat(float);
+        template<typename Float, typename Swapped> void _writeFloat(Float, byte param);
         const void* writeData(internal::tags, slice s);
         const void* _writeString(slice);
         void addingKey();

--- a/Fleece/Core/Internal.hh
+++ b/Fleece/Core/Internal.hh
@@ -23,7 +23,7 @@
 
  0000iiii iiiiiiii       small integer (12-bit, signed, range ±2048)
  0001uccc iiiiiiii...    long integer (u = unsigned?; ccc = byte count - 1) LE integer follows
- 0010s--- --------...    floating point (s = 0:float, 1:double). LE float data follows.
+ 0010ss-- --------...    floating point (see below for `ss` meaning). LE float data follows.
  0011ss-- --------       special (s = 0:null, 1:false, 2:true, 3:undefined)
  0100cccc ssssssss...    string (cccc is byte count, or if it’s 15 then count follows as varint)
  0101cccc dddddddd...    binary data (same as string)
@@ -57,6 +57,13 @@ namespace fleece { namespace impl { namespace internal {
         kArrayTag,
         kDictTag,
         kPointerTagFirst = 8            // 9...15 are also pointers
+    };
+
+    // Interpretation of ss-- in a Float value:
+    enum {
+        kFloatValue32BitSingle  = 0x00,     // 0000  32-bit float
+        kFloatValue32BitDouble  = 0x04,     // 0100  64-bit float encoded as 32-bit w/o data loss
+        kFloatValue64BitDouble  = 0x08,     // 1000  64-bit float
     };
 
     // Interpretation of ss-- in a special value:

--- a/Fleece/Core/Value.cc
+++ b/Fleece/Core/Value.cc
@@ -386,7 +386,7 @@ namespace fleece { namespace impl {
         switch(tag()) {
             case kShortIntTag:
             case kSpecialTag:   return 2;
-            case kFloatTag:     return isDouble() ? 10 : 6;
+            case kFloatTag:     return isEncodedAsDouble() ? 10 : 6;
             case kIntTag:       return 2 + (tinyValue() & 0x07);
             case kStringTag:
             case kBinaryTag:    return (uint8_t*)getStringBytes().end() - (uint8_t*)this;

--- a/Fleece/Core/Value.hh
+++ b/Fleece/Core/Value.hh
@@ -104,7 +104,10 @@ namespace fleece { namespace impl {
         bool isUnsigned() const noexcept FLPURE    {return tag() == internal::kIntTag && (_byte[0] & 0x08) != 0;}
 
         /** Is this a 64-bit floating-point value? */
-        bool isDouble() const noexcept FLPURE      {return tag() == internal::kFloatTag && (_byte[0] & 0x8);}
+        bool isDouble() const noexcept FLPURE      {return tag() == internal::kFloatTag && (_byte[0] & 0xC);}
+
+        /** Is this a 64-bit floating-point value that was _not_ encoded as 32-bit? */
+        bool isEncodedAsDouble() const noexcept FLPURE {return tag() == internal::kFloatTag && (_byte[0] & 0x8);}
 
         /** "undefined" is a special subtype of kNull */
         bool isUndefined() const noexcept FLPURE   {return _byte[0] == ((internal::kSpecialTag << 4) |

--- a/Fleece/Mutable/ValueSlot.cc
+++ b/Fleece/Mutable/ValueSlot.cc
@@ -148,22 +148,26 @@ namespace fleece { namespace impl {
     }
 
 
-    void ValueSlot::set(float f) {
-#if 0 // Perhaps an option in the future?
-        if (Encoder::isIntRepresentable(f)) {
-            set((int32_t)f);
-        } else
-#endif
-        {
-            struct {
-                uint8_t filler = 0;
-                endian::littleEndianFloat le;
-            } data;
-            data.le = f;
-            setValue(kFloatTag, 0, {(char*)&data.le - 1, sizeof(data.le) + 1});
-        }
+    void ValueSlot::set(float f, int tiny) {
+        struct {
+            uint8_t filler = 0;
+            endian::littleEndianFloat le;
+        } data;
+        data.le = f;
+        setValue(kFloatTag, tiny, {(char*)&data.le - 1, sizeof(data.le) + 1});
         assert_postcondition(asValue()->asFloat() == f);
     }
+
+
+    void ValueSlot::set(float f) {
+#if 0 // Perhaps an option in the future?
+        if (Encoder::isIntRepresentable(f))
+            set((int32_t)f);
+        else
+#endif
+        set(f, kFloatValue32BitSingle);
+    }
+
 
     void ValueSlot::set(double d) {
 #if 0 // Perhaps an option in the future?
@@ -172,10 +176,11 @@ namespace fleece { namespace impl {
         } else
 #endif
         if (Encoder::isFloatRepresentable(d)) {
-            set((float)d);
+            set((float)d, kFloatValue32BitDouble);
         } else {
             setPointer(HeapValue::create(d)->asValue());
         }
+        assert_postcondition(asValue()->isDouble());
         assert_postcondition(asValue()->asDouble() == d);
     }
 

--- a/Fleece/Mutable/ValueSlot.hh
+++ b/Fleece/Mutable/ValueSlot.hh
@@ -75,6 +75,7 @@ namespace fleece { namespace impl {
         internal::HeapCollection* makeMutable(internal::tags ifType);
 
     private:
+        void set(float, int tiny);
         bool isPointer() const noexcept FLPURE          {return _tag != kInlineTag;}
         bool isInline() const noexcept FLPURE           {return !isPointer();}
         const Value* pointer() const noexcept FLPURE    {return (const Value*)_pointer;}

--- a/Tests/MutableTests.cc
+++ b/Tests/MutableTests.cc
@@ -49,7 +49,7 @@ namespace fleece {
 
 
     TEST_CASE("MutableArray set values", "[Mutable]") {
-        static constexpr size_t kSize = 17;
+        static constexpr size_t kSize = 18;
         Retained<MutableArray> ma = MutableArray::newArray();
 
         REQUIRE(ma->count() == 0);
@@ -82,16 +82,17 @@ namespace fleece {
         ma->set(8, "Hot dog"_sl);
         ma->set(9, float(M_PI));
         ma->set(10, M_PI);
-        ma->set(11, std::numeric_limits<uint64_t>::max());
-        ma->set(12, (int64_t)0x100000000LL);
-        ma->set(13, (uint64_t)0x100000000ULL);
-        ma->set(14, std::numeric_limits<int64_t>::min());
-        ma->set(15, (int64_t)9223372036854775807LL);
-        ma->set(16, (int64_t)-9223372036854775807LL);
+        ma->set(11, double(123.5));
+        ma->set(12, std::numeric_limits<uint64_t>::max());
+        ma->set(13, (int64_t)0x100000000LL);
+        ma->set(14, (uint64_t)0x100000000ULL);
+        ma->set(15, std::numeric_limits<int64_t>::min());
+        ma->set(16, (int64_t)9223372036854775807LL);
+        ma->set(17, (int64_t)-9223372036854775807LL);
 
         static const valueType kExpectedTypes[kSize] = {
             kNull, kBoolean, kBoolean, kNumber, kNumber, kNumber, kNumber, kNumber, kString,
-            kNumber, kNumber, kNumber, kNumber, kNumber, kNumber, kNumber, kNumber
+            kNumber, kNumber, kNumber, kNumber, kNumber, kNumber, kNumber, kNumber, kNumber
         };
         for (int i = 0; i < 9; i++)
             CHECK(ma->get(i)->type() == kExpectedTypes[i]);
@@ -104,13 +105,17 @@ namespace fleece {
         CHECK(ma->get(7)->asInt() == -123456789);
         CHECK(ma->get(8)->asString() == "Hot dog"_sl);
         CHECK(ma->get(9)->asFloat() == float(M_PI));
+        CHECK_FALSE(ma->get(9)->isDouble());
         CHECK(ma->get(10)->asDouble() == M_PI);
-        CHECK(ma->get(11)->asUnsigned() == std::numeric_limits<uint64_t>::max());
-        CHECK(ma->get(12)->asInt() == 0x100000000LL);
-        CHECK(ma->get(13)->asUnsigned() == 0x100000000ULL);
-        CHECK(ma->get(14)->asInt() == std::numeric_limits<int64_t>::min());
-        CHECK(ma->get(15)->asInt() == 9223372036854775807LL);
-        CHECK(ma->get(16)->asInt() == -9223372036854775807LL);
+        CHECK(ma->get(10)->isDouble());
+        CHECK(ma->get(11)->isDouble());
+        CHECK(ma->get(11)->asDouble() == 123.5);
+        CHECK(ma->get(12)->asUnsigned() == std::numeric_limits<uint64_t>::max());
+        CHECK(ma->get(13)->asInt() == 0x100000000LL);
+        CHECK(ma->get(14)->asUnsigned() == 0x100000000ULL);
+        CHECK(ma->get(15)->asInt() == std::numeric_limits<int64_t>::min());
+        CHECK(ma->get(16)->asInt() == 9223372036854775807LL);
+        CHECK(ma->get(17)->asInt() == -9223372036854775807LL);
 
         {
             MutableArray::iterator i(ma);
@@ -125,17 +130,17 @@ namespace fleece {
         }
 
         CHECK(ma->asArray()->toJSON() == "[null,false,true,0,-123,2017,123456789,-123456789,\"Hot dog\",3.1415927,"
-              "3.141592653589793,18446744073709551615,4294967296,4294967296,"
+              "3.141592653589793,123.5,18446744073709551615,4294967296,4294967296,"
               "-9223372036854775808,9223372036854775807,-9223372036854775807]"_sl);
 
         ma->remove(3, 5);
-        CHECK(ma->count() == 12);
+        CHECK(ma->count() == 13);
         CHECK(ma->get(2)->type() == kBoolean);
         CHECK(ma->get(2)->asBool() == true);
         CHECK(ma->get(3)->type() == kString);
 
         ma->insert(1, 2);
-        CHECK(ma->count() == 14);
+        CHECK(ma->count() == 15);
         REQUIRE(ma->get(1)->type() == kNull);
         REQUIRE(ma->get(2)->type() == kNull);
         CHECK(ma->get(3)->type() == kBoolean);


### PR DESCRIPTION
Some `double` numbers stored in Fleece would be improperly rounded (too few digits of precision) when written to JSON or otherwise converted to strings.

The fix makes a slight change to the Fleece binary format, using a previously unused bit in a float value, but it's backwards compatible.

Fixes #206