### PR TITLE
CBL-5488: DateTime Timezone offset inconsistent

### DIFF
--- a/Fleece/Support/ParseDate.cc
+++ b/Fleece/Support/ParseDate.cc
@@ -496,7 +496,7 @@ namespace fleece {
                 if ( offset_seconds.count() == 0 ) {
                     stream << 'Z';
                 } else {
-                    to_stream(stream, "%Ez", tm, nullptr, &offset_seconds);
+                    to_stream(stream, "%z", tm, nullptr, &offset_seconds);
                 }
             }
         }


### PR DESCRIPTION
CBL3.1 formats timezone as `+0500`, rather than `+05:00`. Restore behaviour to match CBL3.1