### PR TITLE
CBL-5438: DateTime standard format parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 xcuserdata/
 /build/
 /build_cmake/
+.idea/
 DerivedData/
 Tests/1000people.fleece
 Debug/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(FLEECE_BASE_SRC Fleece/API_Impl/FLSlice.cc
                     Fleece/Support/InstanceCounted.cc
                     Fleece/Support/NumConversion.cc
                     Fleece/Support/ParseDate.cc
+                    Fleece/Support/DateFormat.cc
                     Fleece/Support/RefCounted.cc
                     Fleece/Support/Writer.cc
                     Fleece/Support/betterassert.cc

--- a/Fleece.xcodeproj/project.pbxproj
+++ b/Fleece.xcodeproj/project.pbxproj
@@ -211,6 +211,10 @@
 		27F666472017FE7C00A8ED31 /* TempArray.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27F666462017FE7C00A8ED31 /* TempArray.hh */; };
 		27FE87F31E53E43200C5CF3F /* JSONEncoder.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27FE87F11E53E43200C5CF3F /* JSONEncoder.cc */; };
 		27FE87F41E53E43200C5CF3F /* JSONEncoder.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27FE87F21E53E43200C5CF3F /* JSONEncoder.hh */; };
+		EA5529A32B9F48C300B96ACA /* DateFormat.hh in Headers */ = {isa = PBXBuildFile; fileRef = EA5529A12B9F48C300B96ACA /* DateFormat.hh */; };
+		EA5529A42B9F48C300B96ACA /* DateFormat.cc in Sources */ = {isa = PBXBuildFile; fileRef = EA5529A22B9F48C300B96ACA /* DateFormat.cc */; };
+		EA5529A52B9F48CD00B96ACA /* DateFormat.cc in Sources */ = {isa = PBXBuildFile; fileRef = EA5529A22B9F48C300B96ACA /* DateFormat.cc */; };
+		EA5529A62B9F48D500B96ACA /* DateFormat.hh in Headers */ = {isa = PBXBuildFile; fileRef = EA5529A12B9F48C300B96ACA /* DateFormat.hh */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -490,6 +494,8 @@
 		27F666462017FE7C00A8ED31 /* TempArray.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = TempArray.hh; sourceTree = "<group>"; };
 		27FE87F11E53E43200C5CF3F /* JSONEncoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSONEncoder.cc; sourceTree = "<group>"; };
 		27FE87F21E53E43200C5CF3F /* JSONEncoder.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = JSONEncoder.hh; sourceTree = "<group>"; };
+		EA5529A12B9F48C300B96ACA /* DateFormat.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = DateFormat.hh; sourceTree = "<group>"; };
+		EA5529A22B9F48C300B96ACA /* DateFormat.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DateFormat.cc; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -820,6 +826,8 @@
 		27AFF69720EFE6CE0055E966 /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				EA5529A22B9F48C300B96ACA /* DateFormat.cc */,
+				EA5529A12B9F48C300B96ACA /* DateFormat.hh */,
 				2700BBA0218B949900797537 /* Backtrace.hh */,
 				2700BBA1218B949900797537 /* Backtrace.cc */,
 				273CD2D625E874CD00B93C59 /* Base64.hh */,
@@ -1001,6 +1009,7 @@
 				2734B8A01F8583FF00BE5249 /* MArray+ObjC.h in Headers */,
 				270FA2851BF53CEA005DCB13 /* varint.hh in Headers */,
 				277F45B0208E871000A0D159 /* HashTree.hh in Headers */,
+				EA5529A32B9F48C300B96ACA /* DateFormat.hh in Headers */,
 				2734B89F1F8583FF00BE5249 /* MValue.hh in Headers */,
 				27C4CEBB2127976900470DE9 /* betterassert.hh in Headers */,
 				270FA2791BF53CEA005DCB13 /* Value.hh in Headers */,
@@ -1067,6 +1076,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA5529A62B9F48D500B96ACA /* DateFormat.hh in Headers */,
 				27DE2EB22125FA1700123597 /* JSON5.hh in Headers */,
 				27DE2EB32125FA1700123597 /* RefCounted.hh in Headers */,
 				27DE2EB42125FA1700123597 /* JSONDelta.hh in Headers */,
@@ -1348,6 +1358,7 @@
 				274D8248209A5906008BB39F /* ValueSlot.cc in Sources */,
 				274D8252209CF9B3008BB39F /* HeapValue.cc in Sources */,
 				2776AA21208678AA004ACE85 /* DeepIterator.cc in Sources */,
+				EA5529A42B9F48C300B96ACA /* DateFormat.cc in Sources */,
 				27F25A8E20AA053D00E181FA /* Pointer.cc in Sources */,
 				27298E651C00F8A9000CFBA8 /* jsonsl.c in Sources */,
 				270FA27F1BF53CEA005DCB13 /* Writer.cc in Sources */,
@@ -1410,6 +1421,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA5529A52B9F48CD00B96ACA /* DateFormat.cc in Sources */,
 				27744ADE2139C6AE00399DCA /* betterassert.cc in Sources */,
 				273CD2D925E874CD00B93C59 /* Base64.cc in Sources */,
 				27DE2EEB2125FC9300123597 /* FleeceException.cc in Sources */,

--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -17,6 +17,7 @@
 #include "fleece/Fleece.h"
 #include "JSON5.hh"
 #include "ParseDate.hh"
+#include "DateFormat.hh"
 #include "betterassert.hh"
 #include <chrono>
 
@@ -53,7 +54,7 @@ FLTimestamp FLTimestamp_Now() FLAPI {
 
 FLStringResult FLTimestamp_ToString(FLTimestamp timestamp, bool asUTC) FLAPI {
     char str[kFormattedISO8601DateMaxSize];
-    return FLSlice_Copy(FormatISO8601Date(str, timestamp, asUTC, nullptr));
+    return FLSlice_Copy(DateFormat::format(str, timestamp, asUTC, {}));
 }
 
 

--- a/Fleece/Core/Encoder.cc
+++ b/Fleece/Core/Encoder.cc
@@ -19,6 +19,7 @@
 #include "varint.hh"
 #include "FleeceException.hh"
 #include "ParseDate.hh"
+#include "DateFormat.hh"
 #include "fleece/PlatformCompat.hh"
 #include "TempArray.hh"
 #include <algorithm>
@@ -425,7 +426,7 @@ namespace fleece { namespace impl {
 
     void Encoder::writeDateString(int64_t timestamp, bool asUTC) {
         char str[kFormattedISO8601DateMaxSize];
-        writeString(FormatISO8601Date(str, timestamp, asUTC, nullptr));
+        writeString(DateFormat::format(str, timestamp, asUTC, {}));
     }
 
 

--- a/Fleece/Core/Value.cc
+++ b/Fleece/Core/Value.cc
@@ -23,6 +23,7 @@
 #include "fleece/PlatformCompat.hh"
 #include "JSONEncoder.hh"
 #include "ParseDate.hh"
+#include "DateFormat.hh"
 #include <math.h>
 #include "betterassert.hh"
 

--- a/Fleece/Support/DateFormat.cc
+++ b/Fleece/Support/DateFormat.cc
@@ -13,7 +13,7 @@ namespace fleece {
     // YYYY-MM-DDThh:mm:ssTZD
     DateFormat DateFormat::kISO8601 = DateFormat{YMD{Year{}, Month{}, Day{}, YMD::Separator::Hyphen},
                                                  Separator::T,
-                                                 HMS{Hours{}, Minutes{}, Seconds{}, HMS::Separator::Colon},
+                                                 HMS{Hours{}, Minutes{}, Seconds{}, Millis{}, HMS::Separator::Colon},
                                                  {Timezone{}}};
 
     /** This parses a subset of the formatting tokens from "date.h", found 
@@ -321,7 +321,7 @@ namespace fleece {
         }
     }
 
-    slice DateFormat::format(char buf[], int64_t timestamp, minutes tzoffset, std::optional<DateFormat> fmt) {
+    slice DateFormat::format(char buf[], const int64_t timestamp, minutes tzoffset, std::optional<DateFormat> fmt) {
         if ( timestamp == kInvalidDate ) {
             *buf = 0;
             return nullslice;
@@ -341,7 +341,7 @@ namespace fleece {
         if ( f.hms.has_value() ) {
             if ( f.ymd.has_value() ) { stream << (char)f.separator.value(); }
 
-            if ( f.hms.value().millis.has_value() ) {
+            if ( f.hms.value().millis.has_value() && timestamp % 1000 ) {
                 stream << date::format("%T", tm);
             } else {
                 const auto secs = duration_cast<seconds>(millis);
@@ -360,7 +360,7 @@ namespace fleece {
         }
 
         const std::string res = stream.str();
-        std::strncpy(buf, res.c_str(), res.length());
+        strncpy(buf, res.c_str(), res.length());
 
         return {buf, res.length()};
     }

--- a/Fleece/Support/DateFormat.cc
+++ b/Fleece/Support/DateFormat.cc
@@ -1,99 +1,205 @@
 #include "DateFormat.hh"
-#include <cctype>
-#include <exception>
+#include "ParseDate.hh"
+#include "date/date.h"
+#include "fleece/slice.hh"
 #include <optional>
+#include <sstream>
 
 namespace fleece {
-    static size_t separatedSection(slice input, char separator) {
-        auto foundSeparator = input.findByte((unsigned char)separator);
-        if ( !foundSeparator ) return 0;
-        return input.offsetOf(foundSeparator);
-    }
+
+    using namespace std::chrono;
+
+    // YYYY-MM-DDThh:mm:ssTZD
+    DateFormat DateFormat::kISO8601 = DateFormat{YMD{{}, {}, {}, YMD::Separator::Hyphen},
+                                                 Separator::T,
+                                                 HMS{{}, {}, {}, HMS::Separator::Colon},
+                                                 {Timezone{}}};
 
     // %Y-%M-%DT%H:%M:%S
-    std::optional<DateFormat> DateFormat::parseTokenFormat(slice formatString) {}
+    // TODO: Implement!
+    std::optional<DateFormat> DateFormat::parseTokenFormat(slice formatString) { return {}; }
 
     // 1111-11-11T11:11:11.111Z
     std::optional<DateFormat> DateFormat::parseDateFormat(slice formatString) {
-        auto timezone = parseTimezone(formatString);
+        auto timezoneResult = parseTimezone(formatString);
 
-        auto hyphenYearSize = separatedSection(formatString, (char)DateFormat::YMD::Separator::Hyphen);
-        auto slashYearSize  = separatedSection(formatString, (char)DateFormat::YMD::Separator::Slash);
+        if ( timezoneResult.has_value() ) formatString = timezoneResult.value().second;
 
-        auto yearSeparator = DateFormat::YMD::Separator::Hyphen;
-        auto year          = DateFormat::Year::Long;
+        auto tzResult =
+                timezoneResult.has_value() ? std::optional(timezoneResult.value().first) : std::optional<Timezone>();
 
-        if ( hyphenYearSize == 4 || hyphenYearSize == 2 ) {
-            year = hyphenYearSize == 4 ? DateFormat::Year::Long : DateFormat::Year::Short;
-        } else if ( slashYearSize == 4 || slashYearSize == 2 ) {
-            yearSeparator = DateFormat::YMD::Separator::Slash;
-            year          = slashYearSize == 4 ? DateFormat::Year::Long : DateFormat::Year::Short;
+        auto hmsResult = parseHMS(formatString);
+
+        if ( hmsResult.has_value() ) formatString = hmsResult.value().second;
+
+        std::optional<char> separatorChar =
+                formatString.empty() || !hmsResult.has_value() ? std::optional<char>() : formatString[formatString.size - 1];
+
+        std::optional<Separator> separator{};
+
+        if ( separatorChar.has_value() ) {
+            char sep = separatorChar.value();
+            if ( sep == (char)Separator::Space ) {
+                separator = Separator::Space;
+            } else if ( sep == (char)Separator::T ) {
+                separator = Separator::T;
+            } else {
+                // Invalid YMD/HMS Separator
+                return {};
+            }
+            formatString = formatString.upTo(formatString.size - 1);
+        }
+
+        auto ymdResult = parseYMD(formatString);
+
+        if ( separator.has_value() ) {
+            // We must have YMD and HMS if there is a separator.
+            if ( !ymdResult.has_value() || !hmsResult.has_value() ) { return {}; }
+        }
+
+        // We must have HMS if we have timezone specifier.
+        if ( timezoneResult.has_value() && !hmsResult.has_value() ) { return {}; }
+
+        if ( ymdResult.has_value() ) {
+            if ( hmsResult.has_value() ) {
+                if ( !separator.has_value() ) return {};
+                return {{ymdResult.value(), separator.value(), hmsResult.value().first, tzResult}};
+            }
+            return {DateFormat{ymdResult.value()}};
+        } else if ( hmsResult.has_value() ) {
+            return {DateFormat{hmsResult.value().first, tzResult}};
         } else {
+            // We must have _either_ YMD or HMS.
             return {};
         }
-
-        // Skip past the year (now 11-11T11:11:11.111Z)
-        formatString = formatString.from(formatString.findByte((unsigned char)yearSeparator) + 1);
-
-        if ( separatedSection(formatString, (unsigned char)yearSeparator) != 2 ) { return {}; }
-
-        // Skip past month (now 11T11:11:11.111Z)
-        formatString = formatString.from(formatString.findByte((unsigned char)yearSeparator) + 1);
-
-        auto tDaySize     = separatedSection(formatString, (char)DateFormat::Separator::T);
-        auto spaceDaySize = separatedSection(formatString, (char)DateFormat::Separator::Space);
-
-        auto ymdHmsSeparator = DateFormat::Separator::T;
-
-        if ( tDaySize == 2 ) {
-        } else if ( spaceDaySize == 2 ) {
-            ymdHmsSeparator = DateFormat::Separator::Space;
-        } else if ( formatString.size == 2 ) {
-            return {DateFormat{DateFormat::YMD{year, {}, {}, yearSeparator}, ymdHmsSeparator, {}, {}}};
-        } else {
-            // Make sure the bit after this is Z or Time
-        }
-
-        // Skip past day (now 11:11:11.111Z)
-        formatString = formatString.from(formatString.findByte((unsigned char)ymdHmsSeparator) + 1);
-
-        auto timeSeparator = DateFormat::HMS::Separator::Colon;
-
-        if ( separatedSection(formatString, (char)timeSeparator) != true /** TODO: */ ) {}
     }
 
-    std::optional<DateFormat::Timezone> DateFormat::parseTimezone(slice formatString) {
+    std::optional<std::pair<DateFormat::Timezone, slice>> DateFormat::parseTimezone(const slice formatString) {
         // Default to No Colon
-        if ( *(formatString.end() - 1) == 'Z' ) return {Timezone::NoColon};
+        if ( *(formatString.end() - 1) == 'Z' ) return {{Timezone::NoColon, formatString.upTo(formatString.size - 1)}};
         // Minimum 5 `+0000`
         if ( formatString.size < 5 ) return {};
         const bool colon = *(formatString.end() - 3) == ':';
-        if ( colon ) {
-            formatString.setStart(formatString.end() - 6);
-        } else {
-            formatString.setStart(formatString.end() - 5);
-        }
 
-        if ( formatString.hasPrefix('+') || formatString.hasPrefix('-') ) {
+        const size_t start = colon ? formatString.size - 6 : formatString.size - 5;
+
+        if ( formatString[start] == '+' || formatString[start] == '-' ) {
             if ( colon ) {
-                return {Timezone::Colon};
+                return {{Timezone::Colon, formatString.upTo(start)}};
             } else {
-                return {Timezone::NoColon};
+                return {{Timezone::NoColon, formatString.upTo(start)}};
             }
         }
 
         return {};
     }
 
-    std::optional<DateFormat> DateFormat::parse(slice formatString) {
-        if ( formatString.empty() ) { return {}; }
-        unsigned char first = formatString[0];
-        if ( first == '%' ) {
-            return parseTokenFormat(formatString);
+    // Input some string which may or may not contain HMS but does NOT contain timezone. That should have already been
+    // stripped by `parseTimezone` (ie "1111-11-11T11:11:11.111" or "11:11").
+    // Returns the parsed HMS and the format string with HMS removed, or None if valid HMS was not found.
+    std::optional<std::pair<DateFormat::HMS, slice>> DateFormat::parseHMS(slice formatString) {
+        // Minimum 11:11:11
+        if ( formatString.size < 8 ) return {};
+        const bool millis = *(formatString.end() - 4) == '.';
+
+        // If we have millis, we must have minimum 11:11:11.111 (12 chars)
+        if ( millis && formatString.size < 12 ) { return {}; }
+
+        // Shorten to get rid of millis, input minimum is now 11:11:11
+        if ( millis ) { formatString = formatString.upTo(formatString.size - 4); }
+
+        // Check HMS is formatted correctly
+        if ( !(*(formatString.end() - 3) == ':' && *(formatString.end() - 6) == ':') ) { return {}; }
+
+        std::optional<Millis> ms = {};
+
+        if ( millis ) ms = {Millis{}};
+
+        const size_t start = formatString.size - 8;
+
+        if ( ms.has_value() ) {
+            return {{{Hours{}, Minutes{}, Seconds{}, ms.value(), HMS::Separator::Colon}, formatString.upTo(start)}};
+        }
+
+        return {{{Hours{}, Minutes{}, Seconds{}, HMS::Separator::Colon}, formatString.upTo(start)}};
+    }
+
+    // Input some string which may or may not contain YMD but does NOT contain HMS, Timezone, or the YMD/HMS separator (i.e. 'T').
+    // This should be called after already calling `parseTimezone` ,`parseHMS`, and removing the separator.
+    std::optional<DateFormat::YMD> DateFormat::parseYMD(slice formatString) {
+        // Minimum 1111-11-11
+        if ( formatString.size < 10 ) return {};
+
+        auto separator = YMD::Separator::Hyphen;
+
+        if ( *(formatString.end() - 3) == '-' && *(formatString.end() - 6) == '-' ) {
+        } else if ( *(formatString.end() - 3) == '/' && *(formatString.end() - 6) == '/' ) {
+            separator = YMD::Separator::Slash;
         } else {
-            return parseDateFormat(formatString);
+            return {};
+        }
+
+        return {YMD{Year{}, Month{}, Day{}, separator}};
+    }
+
+    std::optional<DateFormat> DateFormat::parse(const slice formatString) {
+        if ( formatString.empty() ) { return {}; }
+        if ( formatString[0] == '%' ) { return parseTokenFormat(formatString); }
+        return parseDateFormat(formatString);
+    }
+
+    slice DateFormat::format(char buf[], int64_t timestamp, bool asUTC, std::optional<DateFormat> fmt) {
+        if ( asUTC ) {
+            return format(buf, timestamp, minutes{0}, fmt);
+        } else {
+            const milliseconds millis{timestamp};
+            auto               temp           = FromTimestamp(floor<seconds>(millis));
+            const seconds      offset_seconds = GetLocalTZOffset(&temp, false);
+            return format(buf, timestamp, duration_cast<minutes>(offset_seconds), fmt);
         }
     }
 
-    std::string DateFormat::format(int64_t timestamp) {}
+    slice DateFormat::format(char buf[], int64_t timestamp, minutes tzoffset, std::optional<DateFormat> fmt) {
+        if ( timestamp == kInvalidDate ) {
+            *buf = 0;
+            return nullslice;
+        }
+
+        std::ostringstream stream{};
+
+        const milliseconds millis{milliseconds{timestamp} + duration_cast<milliseconds>(tzoffset)};
+        const auto         tm = date::local_time<milliseconds>{millis};
+
+        const seconds offset_seconds{tzoffset};
+
+        const DateFormat f = fmt.has_value() ? fmt.value() : kISO8601;
+
+        if ( f.ymd.has_value() ) { stream << date::format("%F", tm); }
+
+        if ( f.hms.has_value() ) {
+            if ( f.ymd.has_value() ) { stream << (char)f.separator.value(); }
+
+            if ( f.hms.value().millis.has_value() ) {
+                stream << date::format("%T", tm);
+            } else {
+                const auto secs = duration_cast<seconds>(millis);
+                stream << date::format("%T", date::local_seconds(secs));
+            }
+
+            if ( f.tz.has_value() ) {
+                if ( offset_seconds.count() == 0 ) {
+                    stream << 'Z';
+                } else {
+                    if ( f.tz.value() == Timezone::Colon ) to_stream(stream, "%Ez", tm, nullptr, &offset_seconds);
+                    else
+                        to_stream(stream, "%z", tm, nullptr, &offset_seconds);
+                }
+            }
+        }
+
+        const std::string res = stream.str();
+        std::strncpy(buf, res.c_str(), res.length());
+
+        return {buf, res.length()};
+    }
 }  // namespace fleece

--- a/Fleece/Support/DateFormat.cc
+++ b/Fleece/Support/DateFormat.cc
@@ -15,6 +15,8 @@ namespace fleece {
 
     // 1111-11-11T11:11:11.111Z
     std::optional<DateFormat> DateFormat::parseDateFormat(slice formatString) {
+        auto timezone = parseTimezone(formatString);
+
         auto hyphenYearSize = separatedSection(formatString, (char)DateFormat::YMD::Separator::Hyphen);
         auto slashYearSize  = separatedSection(formatString, (char)DateFormat::YMD::Separator::Slash);
 
@@ -57,7 +59,31 @@ namespace fleece {
 
         auto timeSeparator = DateFormat::HMS::Separator::Colon;
 
-        if ( separatedSection(formatString, (char)timeSeparator) != ) }
+        if ( separatedSection(formatString, (char)timeSeparator) != true /** TODO: */ ) {}
+    }
+
+    std::optional<DateFormat::Timezone> DateFormat::parseTimezone(slice formatString) {
+        // Default to No Colon
+        if ( *(formatString.end() - 1) == 'Z' ) return {Timezone::NoColon};
+        // Minimum 5 `+0000`
+        if ( formatString.size < 5 ) return {};
+        const bool colon = *(formatString.end() - 3) == ':';
+        if ( colon ) {
+            formatString.setStart(formatString.end() - 6);
+        } else {
+            formatString.setStart(formatString.end() - 5);
+        }
+
+        if ( formatString.hasPrefix('+') || formatString.hasPrefix('-') ) {
+            if ( colon ) {
+                return {Timezone::Colon};
+            } else {
+                return {Timezone::NoColon};
+            }
+        }
+
+        return {};
+    }
 
     std::optional<DateFormat> DateFormat::parse(slice formatString) {
         if ( formatString.empty() ) { return {}; }

--- a/Fleece/Support/DateFormat.cc
+++ b/Fleece/Support/DateFormat.cc
@@ -1,0 +1,73 @@
+#include "DateFormat.hh"
+#include <cctype>
+#include <exception>
+#include <optional>
+
+namespace fleece {
+    static size_t separatedSection(slice input, char separator) {
+        auto foundSeparator = input.findByte((unsigned char)separator);
+        if ( !foundSeparator ) return 0;
+        return input.offsetOf(foundSeparator);
+    }
+
+    // %Y-%M-%DT%H:%M:%S
+    std::optional<DateFormat> DateFormat::parseTokenFormat(slice formatString) {}
+
+    // 1111-11-11T11:11:11.111Z
+    std::optional<DateFormat> DateFormat::parseDateFormat(slice formatString) {
+        auto hyphenYearSize = separatedSection(formatString, (char)DateFormat::YMD::Separator::Hyphen);
+        auto slashYearSize  = separatedSection(formatString, (char)DateFormat::YMD::Separator::Slash);
+
+        auto yearSeparator = DateFormat::YMD::Separator::Hyphen;
+        auto year          = DateFormat::Year::Long;
+
+        if ( hyphenYearSize == 4 || hyphenYearSize == 2 ) {
+            year = hyphenYearSize == 4 ? DateFormat::Year::Long : DateFormat::Year::Short;
+        } else if ( slashYearSize == 4 || slashYearSize == 2 ) {
+            yearSeparator = DateFormat::YMD::Separator::Slash;
+            year          = slashYearSize == 4 ? DateFormat::Year::Long : DateFormat::Year::Short;
+        } else {
+            return {};
+        }
+
+        // Skip past the year (now 11-11T11:11:11.111Z)
+        formatString = formatString.from(formatString.findByte((unsigned char)yearSeparator) + 1);
+
+        if ( separatedSection(formatString, (unsigned char)yearSeparator) != 2 ) { return {}; }
+
+        // Skip past month (now 11T11:11:11.111Z)
+        formatString = formatString.from(formatString.findByte((unsigned char)yearSeparator) + 1);
+
+        auto tDaySize     = separatedSection(formatString, (char)DateFormat::Separator::T);
+        auto spaceDaySize = separatedSection(formatString, (char)DateFormat::Separator::Space);
+
+        auto ymdHmsSeparator = DateFormat::Separator::T;
+
+        if ( tDaySize == 2 ) {
+        } else if ( spaceDaySize == 2 ) {
+            ymdHmsSeparator = DateFormat::Separator::Space;
+        } else if ( formatString.size == 2 ) {
+            return {DateFormat{DateFormat::YMD{year, {}, {}, yearSeparator}, ymdHmsSeparator, {}, {}}};
+        } else {
+            // Make sure the bit after this is Z or Time
+        }
+
+        // Skip past day (now 11:11:11.111Z)
+        formatString = formatString.from(formatString.findByte((unsigned char)ymdHmsSeparator) + 1);
+
+        auto timeSeparator = DateFormat::HMS::Separator::Colon;
+
+        if ( separatedSection(formatString, (char)timeSeparator) != ) }
+
+    std::optional<DateFormat> DateFormat::parse(slice formatString) {
+        if ( formatString.empty() ) { return {}; }
+        unsigned char first = formatString[0];
+        if ( first == '%' ) {
+            return parseTokenFormat(formatString);
+        } else {
+            return parseDateFormat(formatString);
+        }
+    }
+
+    std::string DateFormat::format(int64_t timestamp) {}
+}  // namespace fleece

--- a/Fleece/Support/DateFormat.hh
+++ b/Fleece/Support/DateFormat.hh
@@ -1,0 +1,58 @@
+#include "fleece/slice.hh"
+#include <chrono>
+#include <optional>
+#include <variant>
+
+namespace fleece {
+
+    class DateFormat {
+      public:
+        static std::optional<DateFormat> parse(slice formatString);
+
+        std::string format(int64_t timestamp);
+
+      private:
+        // %Y-%M-%DT%H:%M:%S
+        static std::optional<DateFormat> parseTokenFormat(slice formatString);
+
+        // 1111-11-11T11:11:11
+        static std::optional<DateFormat> parseDateFormat(slice formatString);
+
+        // Short = YY, Long = YYYY
+        enum class Year : uint8_t { Short, Long };
+        enum class Month : uint8_t {};
+        enum class Day : uint8_t {};
+        enum class Hours : uint8_t {};
+        enum class Minutes : uint8_t {};
+        enum class Seconds : uint8_t {};
+        enum class Millis : uint8_t {};
+        enum class Timezone : uint8_t {};
+        enum class Separator : char { Space = ' ', T = 'T' };
+
+        struct YMD {
+            enum class Separator : char { Hyphen = '-', Slash = '/' };
+            Year      year;
+            Month     month;
+            Day       day;
+            Separator separator;
+        };
+
+        struct HMS {
+            enum class Separator : char { Colon = ':' };
+            Hours     hours;
+            Minutes   minutes;
+            Seconds   seconds;
+            Millis    millis;
+            Separator separator;
+        };
+
+        DateFormat(YMD ymd, Separator separator, std::optional<HMS> hms = {}, std::optional<Timezone> tz = {})
+            : ymd{ymd}, separator{separator}, hms{hms}, tz{tz} {}
+
+        YMD                     ymd;
+        Separator               separator;
+        std::optional<HMS>      hms;
+        std::optional<Timezone> tz;
+    };
+
+}  // namespace fleece

--- a/Fleece/Support/DateFormat.hh
+++ b/Fleece/Support/DateFormat.hh
@@ -20,7 +20,7 @@ namespace fleece {
                     kFormattedISO8601DateMaxSize bytes must be available.
         @param timestamp  The timestamp (milliseconds since 1/1/1970).
         @param asUTC  True to format as UTC, false to use the local time-zone.
-        @param format The model to use for formatting (i.e. which portions to include).
+        @param fmt The model to use for formatting (i.e. which portions to include).
                       If null, then the full ISO-8601 format is used
         @return  The formatted string (points to `buf`). */
         static slice format(char buf[], int64_t timestamp, bool asUTC, std::optional<DateFormat> fmt);

--- a/Fleece/Support/DateFormat.hh
+++ b/Fleece/Support/DateFormat.hh
@@ -12,11 +12,6 @@ namespace fleece {
         std::string format(int64_t timestamp);
 
       private:
-        // %Y-%M-%DT%H:%M:%S
-        static std::optional<DateFormat> parseTokenFormat(slice formatString);
-
-        // 1111-11-11T11:11:11
-        static std::optional<DateFormat> parseDateFormat(slice formatString);
 
         // Short = YY, Long = YYYY
         enum class Year : uint8_t { Short, Long };
@@ -26,7 +21,7 @@ namespace fleece {
         enum class Minutes : uint8_t {};
         enum class Seconds : uint8_t {};
         enum class Millis : uint8_t {};
-        enum class Timezone : uint8_t {};
+        enum class Timezone : uint8_t { NoColon, Colon };
         enum class Separator : char { Space = ' ', T = 'T' };
 
         struct YMD {
@@ -48,6 +43,14 @@ namespace fleece {
 
         DateFormat(YMD ymd, Separator separator, std::optional<HMS> hms = {}, std::optional<Timezone> tz = {})
             : ymd{ymd}, separator{separator}, hms{hms}, tz{tz} {}
+
+        // %Y-%M-%DT%H:%M:%S
+        static std::optional<DateFormat> parseTokenFormat(slice formatString);
+
+        // 1111-11-11T11:11:11
+        static std::optional<DateFormat> parseDateFormat(slice formatString);
+
+        static std::optional<Timezone> parseTimezone(slice formatString);
 
         YMD                     ymd;
         Separator               separator;

--- a/Fleece/Support/DateFormat.hh
+++ b/Fleece/Support/DateFormat.hh
@@ -38,7 +38,6 @@ namespace fleece {
 
         static DateFormat kISO8601;
 
-      private:
         enum class Year : uint8_t {};
         enum class Month : uint8_t {};
         enum class Day : uint8_t {};
@@ -54,6 +53,10 @@ namespace fleece {
 
             YMD(const Year y, const Month m, const Day d, const Separator sep)
                 : year(y), month(m), day(d), separator(sep) {}
+
+            bool operator==(const YMD& other) const;
+
+            static YMD kISO8601;
 
             Year      year;
             Month     month;
@@ -72,6 +75,10 @@ namespace fleece {
             HMS(const Hours h, const Minutes m, const Seconds s, const Millis ms, const Separator sep)
                 : hours{h}, minutes{m}, seconds{s}, millis{ms}, separator{sep} {}
 
+            bool operator==(const HMS& other) const;
+
+            static HMS kISO8601;
+
             Hours                  hours;
             Minutes                minutes;
             std::optional<Seconds> seconds;
@@ -89,6 +96,12 @@ namespace fleece {
         // 11:11:11(Z)
         explicit DateFormat(HMS hms, const std::optional<Timezone> tz = {}) : hms{hms}, tz{tz} {}
 
+        bool operator ==(const DateFormat& other) const;
+        bool operator !=(const DateFormat& other) const { return !(*this==other); }
+
+        explicit operator std::string() const;
+
+      private:
         // %Y-%M-%DT%H:%M:%S
         static std::optional<DateFormat> parseTokenFormat(slice formatString);
 
@@ -106,5 +119,9 @@ namespace fleece {
         std::optional<HMS>       hms;
         std::optional<Timezone>  tz;
     };
+
+    std::ostream& operator << (std::ostream& os, DateFormat const& df);
+
+    std::ostream& operator << (std::ostream& os, std::optional<DateFormat> const& odf);
 
 }  // namespace fleece

--- a/Fleece/Support/DateFormat.hh
+++ b/Fleece/Support/DateFormat.hh
@@ -1,20 +1,45 @@
+#pragma once
+
 #include "fleece/slice.hh"
 #include <chrono>
 #include <optional>
-#include <variant>
 
 namespace fleece {
+
+    static constexpr int64_t kInvalidDate = INT64_MIN;
+
+    /** Maximum length of a formatted ISO-8601 date. (Actually it's a bit bigger.) */
+    static constexpr size_t kFormattedISO8601DateMaxSize = 40;
 
     class DateFormat {
       public:
         static std::optional<DateFormat> parse(slice formatString);
 
-        std::string format(int64_t timestamp);
+        /** Formats a timestamp (milliseconds since 1/1/1970) as an ISO-8601 date-time.
+        @param buf  The location to write the formatted C string. At least
+                    kFormattedISO8601DateMaxSize bytes must be available.
+        @param timestamp  The timestamp (milliseconds since 1/1/1970).
+        @param asUTC  True to format as UTC, false to use the local time-zone.
+        @param format The model to use for formatting (i.e. which portions to include).
+                      If null, then the full ISO-8601 format is used
+        @return  The formatted string (points to `buf`). */
+        static slice format(char buf[], int64_t timestamp, bool asUTC, std::optional<DateFormat> fmt);
+
+        /** Formats a timestamp (milliseconds since 1/1/1970) as an ISO-8601 date-time.
+        @param buf  The location to write the formatted C string. At least
+                    kFormattedISO8601DateMaxSize bytes must be available.
+        @param timestamp  The timestamp (milliseconds since 1/1/1970).
+        @param tzoffset   The timezone offset from UTC in minutes
+        @param fmt The model to use for formatting (i.e. which portions to include).
+                      If null, then the full ISO-8601 format is used
+        @return  The formatted string (points to `buf`). */
+        static slice format(char buf[], int64_t timestamp, std::chrono::minutes tzoffset,
+                            std::optional<DateFormat> fmt);
+
+        static DateFormat kISO8601;
 
       private:
-
-        // Short = YY, Long = YYYY
-        enum class Year : uint8_t { Short, Long };
+        enum class Year : uint8_t {};
         enum class Month : uint8_t {};
         enum class Day : uint8_t {};
         enum class Hours : uint8_t {};
@@ -26,6 +51,10 @@ namespace fleece {
 
         struct YMD {
             enum class Separator : char { Hyphen = '-', Slash = '/' };
+
+            YMD(const Year y, const Month m, const Day d, const Separator sep)
+                : year(y), month(m), day(d), separator(sep) {}
+
             Year      year;
             Month     month;
             Day       day;
@@ -34,15 +63,31 @@ namespace fleece {
 
         struct HMS {
             enum class Separator : char { Colon = ':' };
-            Hours     hours;
-            Minutes   minutes;
-            Seconds   seconds;
-            Millis    millis;
-            Separator separator;
+
+            // 11:11:11
+            HMS(const Hours h, const Minutes m, const Seconds s, const Separator sep)
+                : hours{h}, minutes{m}, seconds{s}, separator{sep} {}
+
+            // 11:11:11.111
+            HMS(const Hours h, const Minutes m, const Seconds s, const Millis ms, const Separator sep)
+                : hours{h}, minutes{m}, seconds{s}, millis{ms}, separator{sep} {}
+
+            Hours                  hours;
+            Minutes                minutes;
+            std::optional<Seconds> seconds;
+            std::optional<Millis>  millis;
+            Separator              separator;
         };
 
-        DateFormat(YMD ymd, Separator separator, std::optional<HMS> hms = {}, std::optional<Timezone> tz = {})
+        // 1111-11-11T11:11:11(Z)
+        DateFormat(YMD ymd, Separator separator, HMS hms, const std::optional<Timezone> tz = {})
             : ymd{ymd}, separator{separator}, hms{hms}, tz{tz} {}
+
+        // 11-11-11
+        explicit DateFormat(YMD ymd) : ymd{ymd} {}
+
+        // 11:11:11(Z)
+        explicit DateFormat(HMS hms, const std::optional<Timezone> tz = {}) : hms{hms}, tz{tz} {}
 
         // %Y-%M-%DT%H:%M:%S
         static std::optional<DateFormat> parseTokenFormat(slice formatString);
@@ -50,12 +95,16 @@ namespace fleece {
         // 1111-11-11T11:11:11
         static std::optional<DateFormat> parseDateFormat(slice formatString);
 
-        static std::optional<Timezone> parseTimezone(slice formatString);
+        static std::optional<std::pair<Timezone, slice>> parseTimezone(slice formatString);
 
-        YMD                     ymd;
-        Separator               separator;
-        std::optional<HMS>      hms;
-        std::optional<Timezone> tz;
+        static std::optional<std::pair<HMS, slice>> parseHMS(slice formatString);
+
+        static std::optional<YMD> parseYMD(slice formatString);
+
+        std::optional<YMD>       ymd;
+        std::optional<Separator> separator;
+        std::optional<HMS>       hms;
+        std::optional<Timezone>  tz;
     };
 
 }  // namespace fleece

--- a/Fleece/Support/JSONEncoder.cc
+++ b/Fleece/Support/JSONEncoder.cc
@@ -14,6 +14,7 @@
 #include "FleeceImpl.hh"
 #include "SmallVector.hh"
 #include "ParseDate.hh"
+#include "DateFormat.hh"
 #include <algorithm>
 #include "betterassert.hh"
 
@@ -62,7 +63,7 @@ namespace fleece { namespace impl {
 
     void JSONEncoder::writeDateString(int64_t timestamp, bool asUTC) {
         char str[kFormattedISO8601DateMaxSize];
-        writeString(FormatISO8601Date(str, timestamp, asUTC, nullptr));
+        writeString(DateFormat::format(str, timestamp, asUTC, {}));
     }
 
 

--- a/Fleece/Support/ParseDate.cc
+++ b/Fleece/Support/ParseDate.cc
@@ -68,8 +68,6 @@
 #include <cmath>
 #include <ctime>
 #include <mutex>
-#include <chrono>
-#include <sstream>
 #include <map>
 #include <algorithm>
 #include <cctype>

--- a/Fleece/Support/ParseDate.hh
+++ b/Fleece/Support/ParseDate.hh
@@ -19,8 +19,6 @@
 namespace fleece {
     using namespace std::chrono;
 
-    static constexpr int64_t kInvalidDate = INT64_MIN;
-
     typedef enum {
         kDateComponentMillennium,
         kDateComponentCentury,
@@ -80,29 +78,6 @@ namespace fleece {
     /** Parses a C string as a date component (valid strings are represented by the DateComponent
         enum above) */
     DateComponent ParseDateComponent(slice component);
-
-    /** Maximum length of a formatted ISO-8601 date. (Actually it's a bit bigger.) */
-    static constexpr size_t kFormattedISO8601DateMaxSize = 40;
-
-    /** Formats a timestamp (milliseconds since 1/1/1970) as an ISO-8601 date-time.
-        @param buf  The location to write the formatted C string. At least
-                    kFormattedISO8601DateMaxSize bytes must be available.
-        @param timestamp  The timestamp (milliseconds since 1/1/1970).
-        @param asUTC  True to format as UTC, false to use the local time-zone.
-        @param format The model to use for formatting (i.e. which portions to include).
-                      If null, then the full ISO-8601 format is used
-        @return  The formatted string (points to `buf`). */
-    slice FormatISO8601Date(char buf[], int64_t timestamp, bool asUTC, const DateTime* format);
-
-    /** Formats a timestamp (milliseconds since 1/1/1970) as an ISO-8601 date-time.
-        @param buf  The location to write the formatted C string. At least
-                    kFormattedISO8601DateMaxSize bytes must be available.
-        @param timestamp  The timestamp (milliseconds since 1/1/1970).
-        @param tzoffset   The timezone offset from UTC in minutes
-        @param format The model to use for formatting (i.e. which portions to include).
-                      If null, then the full ISO-8601 format is used
-        @return  The formatted string (points to `buf`). */
-    slice FormatISO8601Date(char buf[], int64_t timestamp, minutes tzoffset, const DateTime* format);
 
     /** Creates a tm out of a timestamp, but it will not be fully valid until
         passed through mktime.

--- a/Tests/SupportTests.cc
+++ b/Tests/SupportTests.cc
@@ -351,50 +351,47 @@ TEST_CASE("DateTime Format parser", "[Timestamps]") {
     std::vector<std::pair<std::string, std::optional<DateFormat>>> tests{};
 
     SECTION("Valid Formats") {
-        tests = {
-                {"%F", DateFormat{DateFormat::YMD::kISO8601}},
-                {"%Y-%m-%d", DateFormat{DateFormat::YMD::kISO8601}},
-                {"%Y/%m/%d", DateFormat{DateFormat::YMD{{}, {}, {}, DateFormat::YMD::Separator::Slash}}},
-                {"%FT%T",
-                 DateFormat{DateFormat::YMD::kISO8601, DateFormat::Separator::T, DateFormat::HMS::kISO8601}},
-                {"%FT%H:%M:%S",
-                 DateFormat{DateFormat::YMD::kISO8601, DateFormat::Separator::T, DateFormat::HMS{{}, {}, {}, DateFormat::HMS::Separator::Colon}}},
-                {"%F %T",
-                 DateFormat{DateFormat::YMD::kISO8601, DateFormat::Separator::Space, DateFormat::HMS::kISO8601}},
-                {"%FT%H:%M:%S.%s",
-                 DateFormat{DateFormat::YMD::kISO8601, DateFormat::Separator::T, DateFormat::HMS::kISO8601}},
-                {"%FT%H:%M:%S%s", DateFormat{DateFormat::YMD::kISO8601, DateFormat::Separator::T, DateFormat::HMS::kISO8601}},
-                {"%FT%T%z", DateFormat::kISO8601},
-                {"%FT%T%Ez", DateFormat{DateFormat::YMD::kISO8601, DateFormat::Separator::T, DateFormat::HMS::kISO8601,
+        tests = {{"%F", DateFormat{DateFormat::YMD::kISO8601}},
+                 {"%Y-%m-%d", DateFormat{DateFormat::YMD::kISO8601}},
+                 {"%Y/%m/%d", DateFormat{DateFormat::YMD{{}, {}, {}, DateFormat::YMD::Separator::Slash}}},
+                 {"%FT%T", DateFormat{DateFormat::YMD::kISO8601, DateFormat::Separator::T, DateFormat::HMS::kISO8601}},
+                 {"%FT%H:%M:%S", DateFormat{DateFormat::YMD::kISO8601, DateFormat::Separator::T,
+                                            DateFormat::HMS{{}, {}, {}, DateFormat::HMS::Separator::Colon}}},
+                 {"%F %T",
+                  DateFormat{DateFormat::YMD::kISO8601, DateFormat::Separator::Space, DateFormat::HMS::kISO8601}},
+                 {"%FT%H:%M:%S.%s",
+                  DateFormat{DateFormat::YMD::kISO8601, DateFormat::Separator::T, DateFormat::HMS::kISO8601}},
+                 {"%FT%H:%M:%S%s",
+                  DateFormat{DateFormat::YMD::kISO8601, DateFormat::Separator::T, DateFormat::HMS::kISO8601}},
+                 {"%FT%T%z", DateFormat::kISO8601},
+                 {"%FT%T%Ez", DateFormat{DateFormat::YMD::kISO8601, DateFormat::Separator::T, DateFormat::HMS::kISO8601,
                                          DateFormat::Timezone::Colon}},
-                {"%T%s%z", DateFormat{DateFormat::HMS::kISO8601, DateFormat::Timezone::NoColon}}};
+                 {"%T%s%z", DateFormat{DateFormat::HMS::kISO8601, DateFormat::Timezone::NoColon}}};
     }
 
     SECTION("Invalid Formats") {
-        tests = {
-            // Only YMD order is allowed
-            {"%m/%d/%Y", {}},
-            {"%m-%d-%Y", {}},
-            // Separator is required
-            {"%Y%m%d", {}},
-            {"%F%T", {}},
-            // YMD must come before HMS
-            {"%T%F", {}},
-            // Must choose from available separators
-            {"%F*%T", {}},
-            // Cannot have timezone without HMS
-            {"%F%z", {}},
-            {"%F%Ez", {}},
-            {"%z", {}}
-        };
+        tests = {// Only YMD order is allowed
+                 {"%m/%d/%Y", {}},
+                 {"%m-%d-%Y", {}},
+                 // Separator is required
+                 {"%Y%m%d", {}},
+                 {"%F%T", {}},
+                 // YMD must come before HMS
+                 {"%T%F", {}},
+                 // Must choose from available separators
+                 {"%F*%T", {}},
+                 // Cannot have timezone without HMS
+                 {"%F%z", {}},
+                 {"%F%Ez", {}},
+                 {"%z", {}}};
     }
 
-    for (const auto& [formatString, expected] : tests ) {
+    for ( const auto& [formatString, expected] : tests ) {
         const auto result = DateFormat::parse(formatString);
         CHECK(result == expected);
-        if (result != expected) {
-            std::cerr << "Format string '" << formatString << "' produced result '"
-                      << result << "' which is not equal to expected '" << expected << "'" << std::endl;
+        if ( result != expected ) {
+            std::cerr << "Format string '" << formatString << "' produced result '" << result
+                      << "' which is not equal to expected '" << expected << "'" << std::endl;
         }
     }
 }

--- a/cmake/platform_base.cmake
+++ b/cmake/platform_base.cmake
@@ -40,6 +40,7 @@ function(set_source_files_base)
         Fleece/Support/JSONEncoder.cc
         Fleece/Support/LibC++Debug.cc
         Fleece/Support/ParseDate.cc
+        Fleece/Support/DateFormat.cc
         Fleece/Support/RefCounted.cc
         Fleece/Support/slice_stream.cc
         Fleece/Support/sliceIO.cc


### PR DESCRIPTION
A proper parser for DateTime formats, rather than just parsing format string as a DateTime.
This has benefits such as additional flexibility in future, but also allows us to keep consistent with the strange "almost-ISO" date format we shipped with CBL 3.1, because keeping format as a `DateTime` does not allow us to optionally use colon or no-colon for Timezone offset (i.e. `+0500` / `+05:00`).
I added in parsing for a "subset" of https://howardhinnant.github.io/date/date.html#to_stream_formatting, but it's not necessary and if anyone thinks we don't need it, happy to take it out. Think it's a lot better than the weird "1111-11-11T11:11......` format we copied from Server though.