### PR TITLE
Define _LIBCPP_REMOVE_TRANSITIVE_INCLUDES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ foreach(platform FleeceObjects Fleece FleeceStatic FleeceBase fleeceTool FleeceT
         ${platform} PRIVATE
         HAS_UNCAUGHT_EXCEPTIONS # date.h use std::uncaught_exceptions instead of std::uncaught_exception
         __STDC_FORMAT_MACROS # To use PRIx64 and friends for formatting variable size types in printf
+        _LIBCPP_REMOVE_TRANSITIVE_INCLUDES # Stop libc++ headers from including extra headers
     )
 endforeach()
 

--- a/Fleece/Support/betterassert.cc
+++ b/Fleece/Support/betterassert.cc
@@ -11,6 +11,7 @@
 //
 
 #include "betterassert.hh"
+#include <exception>
 #include <stdio.h>
 #include <string.h>
 

--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -61,5 +61,9 @@ COMBINE_HIDPI_IMAGES                               = YES    // Stop Xcode from c
 
 SUPPORTS_MACCATALYST                               = YES
 
-// Make memset_s available
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) __STDC_WANT_LIB_EXT1__=1
+// * Defining `__STDC_WANT_LIB_EXT1__=1` makes C11 Annex K fns like  `memset_s` available.
+// * Defining `_LIBCPP_REMOVE_TRANSITIVE_INCLUDES` stops libc++'s headers from including other
+//   libc++ headers except as defined in the language standard. This is a good idea because it will
+//   catch situations where a header isn't explicitly included, which will cause build errors with
+//   other standard libs like GCC's and MSVC's.
+GCC_PREPROCESSOR_DEFINITIONS = $(GCC_PREPROCESSOR_DEFINITIONS) __STDC_WANT_LIB_EXT1__=1 _LIBCPP_REMOVE_TRANSITIVE_INCLUDES


### PR DESCRIPTION
Defining `_LIBCPP_REMOVE_TRANSITIVE_INCLUDES` stops libc++'s headers from including other libc++ headers except as defined in the language standard. This is a good idea because it will catch situations where a header isn't explicitly included, which will cause build errors with other standard libs like GCC's and MSVC's.