### PR TITLE
CBL 5311 : Increase Rev Tree Depth Limit to 100.

### DIFF
--- a/Fleece/Core/JSONConverter.cc
+++ b/Fleece/Core/JSONConverter.cc
@@ -32,7 +32,7 @@ namespace fleece { namespace impl {
 
     JSONConverter::JSONConverter(Encoder &e) noexcept
     :_encoder(e),
-     _jsn(jsonsl_new(50)),      // never returns nullptr, according to source code
+     _jsn(jsonsl_new(102)),     // never returns nullptr, according to source code. 102 allows 100 logical levels.
      _jsonError(JSONSL_ERROR_SUCCESS),
      _errorPos(0)
     {


### PR DESCRIPTION
This requires to increase the static limit of depth that the JSON parser can handle.

Ported from CBL 5124