### PR TITLE
Explicit convert UINT64_MAX to unsigned

### DIFF
--- a/Tests/ObjCTests.mm
+++ b/Tests/ObjCTests.mm
@@ -62,8 +62,7 @@ TEST_CASE("Obj-C Ints", "[Encoder]") {
     checkIt(@123456789,     "123456789");
     checkIt(@123456789012,  "123456789012");
     checkIt(@(INT64_MAX),   "9223372036854775807");
-    // checkIt(@(UINT64_MAX),  "18446744073709551615");
-    // The above may fail to turn UINT64_MAX to unsigned. In the following,
+    // It was found that @() may not turn UINT64_MAX to unsigned. In the following,
     // we apply an explicit conversion
     checkIt(@([@UINT64_MAX unsignedLongLongValue]), "18446744073709551615");
 }

--- a/Tests/ObjCTests.mm
+++ b/Tests/ObjCTests.mm
@@ -62,7 +62,10 @@ TEST_CASE("Obj-C Ints", "[Encoder]") {
     checkIt(@123456789,     "123456789");
     checkIt(@123456789012,  "123456789012");
     checkIt(@(INT64_MAX),   "9223372036854775807");
-    checkIt(@(UINT64_MAX),  "18446744073709551615");
+    // checkIt(@(UINT64_MAX),  "18446744073709551615");
+    // The above may fail to turn UINT64_MAX to unsigned. In the following,
+    // we apply an explicit conversion
+    checkIt(@([@UINT64_MAX unsignedLongLongValue]), "18446744073709551615");
 }
 
 TEST_CASE("Obj-C Floats", "[Encoder]") {


### PR DESCRIPTION
In Jenkins' build machine (MacOS), we found it failed to convert UINT64_MAX to unsigned with @() after we upgraded MACOSX_DEVELOPMENT_TARGET to 12 from 10.14.

A test is falied because of it. Fix it by explicit cast.