### PR TITLE
Explicit convert UINT64_MAX to unsigned

### DIFF
--- a/Tests/ObjCTests.mm
+++ b/Tests/ObjCTests.mm
@@ -62,7 +62,9 @@ TEST_CASE("Obj-C Ints", "[Encoder]") {
     checkIt(@123456789,     "123456789");
     checkIt(@123456789012,  "123456789012");
     checkIt(@(INT64_MAX),   "9223372036854775807");
-    checkIt(@(UINT64_MAX),  "18446744073709551615");
+    // It was found that @() may not turn UINT64_MAX to unsigned. In the following,
+    // we create unsignedLongLong explicitly
+    checkIt([NSNumber numberWithUnsignedLongLong:UINT64_MAX], "18446744073709551615");
 }
 
 TEST_CASE("Obj-C Floats", "[Encoder]") {


### PR DESCRIPTION
In Jenkins' build machine (MacOS), we found it failed to convert UINT64_MAX to unsigned with @() after we upgraded MACOSX_DEVELOPMENT_TARGET to 12 from 10.14. A test failed because of it. Fix it by creating an NSNumber with unsignedLongLong.