### PR TITLE
CBL-5686: Fix GCC 'nonull' warnings

### DIFF
--- a/API/fleece/CompilerSupport.h
+++ b/API/fleece/CompilerSupport.h
@@ -12,62 +12,62 @@
 
 #pragma once
 #ifndef _FLEECE_COMPILER_SUPPORT_H
-#define _FLEECE_COMPILER_SUPPORT_H
+#    define _FLEECE_COMPILER_SUPPORT_H
 
 // The __has_xxx() macros are supported by [at least] Clang and GCC.
 // Define them to return 0 on other compilers.
 // https://clang.llvm.org/docs/AttributeReference.html
 // https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
 
-#ifndef __has_attribute
-    #define __has_attribute(x) 0
-#endif
+#    ifndef __has_attribute
+#        define __has_attribute(x) 0
+#    endif
 
-#ifndef __has_builtin
-    #define __has_builtin(x) 0
-#endif
+#    ifndef __has_builtin
+#        define __has_builtin(x) 0
+#    endif
 
-#ifndef __has_feature
-    #define __has_feature(x) 0
-#endif
+#    ifndef __has_feature
+#        define __has_feature(x) 0
+#    endif
 
-#ifndef __has_extension
-    #define __has_extension(x) 0
-#endif
+#    ifndef __has_extension
+#        define __has_extension(x) 0
+#    endif
 
 
 // Tells the optimizer that a function's return value is never NULL.
-#if __has_attribute(returns_nonnull)
-#  define RETURNS_NONNULL               __attribute__((returns_nonnull))
-#else
-#  define RETURNS_NONNULL
-#endif
+#    if __has_attribute(returns_nonnull)
+#        define RETURNS_NONNULL __attribute__((returns_nonnull))
+#    else
+#        define RETURNS_NONNULL
+#    endif
 
 // deprecated; use NODISCARD instead
-#if __has_attribute(returns_nonnull)
-#  define MUST_USE_RESULT               __attribute__((warn_unused_result))
-#else
-#  define MUST_USE_RESULT
-#endif
+#    if __has_attribute(returns_nonnull)
+#        define MUST_USE_RESULT __attribute__((warn_unused_result))
+#    else
+#        define MUST_USE_RESULT
+#    endif
 
 // NODISCARD expands to the C++17/C23 `[[nodiscard]]` attribute, or else MUST_USE_RESULT.
 // (We can't just redefine MUST_USE_RESULT as `[[nodiscard]]` unfortunately, because the former is
 // already in use in positions where `[[nodiscard]]` isn't valid, like at the end of a declaration.)
-#if (__cplusplus >= 201700L) || (__STDC_VERSION__ >= 202000)
-#  define NODISCARD                     [[nodiscard]]
-#else
-#  define NODISCARD                     MUST_USE_RESULT
-#endif
+#    if ( __cplusplus >= 201700L ) || (__STDC_VERSION__ >= 202000)
+#        define NODISCARD [[nodiscard]]
+#    else
+#        define NODISCARD MUST_USE_RESULT
+#    endif
 
 // These have no effect on behavior, but they hint to the optimizer which branch of an 'if'
 // statement to make faster.
-#if __has_builtin(__builtin_expect)
-#define _usuallyTrue(VAL)               __builtin_expect(VAL, true)
-#define _usuallyFalse(VAL)              __builtin_expect(VAL, false)
-#else
-#define _usuallyTrue(VAL)               (VAL)
-#define _usuallyFalse(VAL)              (VAL)
-#endif
+#    if __has_builtin(__builtin_expect)
+#        define _usuallyTrue(VAL)  __builtin_expect(VAL, true)
+#        define _usuallyFalse(VAL) __builtin_expect(VAL, false)
+#    else
+#        define _usuallyTrue(VAL)  (VAL)
+#        define _usuallyFalse(VAL) (VAL)
+#    endif
 
 
 // Nullability annotations, for function parameters and struct fields.
@@ -75,33 +75,19 @@
 // disallow NULL values, unless annotated with FL_NULLABLE (which must come after the `*`.)
 // (FL_NONNULL is occasionally necessary when there are multiple levels of pointers.)
 // NOTE: Only supported in Clang, so far.
-#if __has_feature(nullability)
-#  define FL_ASSUME_NONNULL_BEGIN _Pragma("clang assume_nonnull begin")
-#  define FL_ASSUME_NONNULL_END _Pragma("clang assume_nonnull end")
-#  define FL_NULLABLE _Nullable
-#  define FL_NONNULL _Nonnull
-#  define FL_RETURNS_NONNULL __attribute__((returns_nonnull))
-#else
-#  define FL_ASSUME_NONNULL_BEGIN
-#  define FL_ASSUME_NONNULL_END
-#  define FL_NULLABLE
-#  define FL_NONNULL
-#  define FL_RETURNS_NONNULL
-#endif
-
-
-// Declares that a parameter must not be NULL. The compiler can sometimes detect violations
-// of this at compile time, if the parameter value is a literal.
-// The Clang Undefined-Behavior Sanitizer will detect all violations at runtime.
-// GCC also has an attribute with this name, but it's incompatible: it can't be applied to a
-// parameter, it has to come after the function and list parameters by number. Oh well.
-// TODO: Replace this with the better nullability annotations above.
-#if __has_attribute(nonnull)
-#  define NONNULL                       __attribute__((nonnull))
-#else
-#  define NONNULL
-#endif
-
+#    if __has_feature(nullability)
+#        define FL_ASSUME_NONNULL_BEGIN _Pragma("clang assume_nonnull begin")
+#        define FL_ASSUME_NONNULL_END   _Pragma("clang assume_nonnull end")
+#        define FL_NULLABLE             _Nullable
+#        define FL_NONNULL              _Nonnull
+#        define FL_RETURNS_NONNULL      __attribute__((returns_nonnull))
+#    else
+#        define FL_ASSUME_NONNULL_BEGIN
+#        define FL_ASSUME_NONNULL_END
+#        define FL_NULLABLE
+#        define FL_NONNULL
+#        define FL_RETURNS_NONNULL
+#    endif
 
 // FLPURE functions are _read-only_. They cannot write to memory (in a way that's detectable),
 // and they cannot access volatile data or do I/O.
@@ -117,11 +103,11 @@
 //  declared with the pure attribute can safely read any non-volatile objects, and modify the value
 //  of objects in a way that does not affect their return value or the observable state of the
 //  program." -- GCC manual
-#if __has_attribute(__pure__)
-#  define FLPURE                        __attribute__((__pure__))
-#else
-#  define FLPURE
-#endif
+#    if __has_attribute(__pure__)
+#        define FLPURE __attribute__((__pure__))
+#    else
+#        define FLPURE
+#    endif
 
 // FLCONST is even stricter than FLPURE. The function cannot access memory at all (except for
 // reading immutable values like constants.) The return value can only depend on the parameters.
@@ -139,23 +125,23 @@
 // "In general, since a function cannot distinguish data that might change from data that cannot,
 //  const functions should never take pointer or, in C++, reference arguments. Likewise, a function
 //  that calls a non-const function usually must not be const itself." -- GCC manual
-#if __has_attribute(__const__)
-#  define FLCONST                     __attribute__((__const__))
-#else
-#  define FLCONST
-#endif
+#    if __has_attribute(__const__)
+#        define FLCONST __attribute__((__const__))
+#    else
+#        define FLCONST
+#    endif
 
 
 // `constexpr14` is for uses of `constexpr` that are valid in C++14 but not earlier.
 // In constexpr functions this includes `if`, `for`, `while` statements; or multiple `return`s.
 // The macro expands to `constexpr` in C++14 or later, otherwise to nothing.
-#ifdef __cplusplus
-    #if __cplusplus >= 201400L || _MSVC_LANG >= 201400L
-        #define constexpr14 constexpr
-    #else
-        #define constexpr14
-    #endif
-#endif // __cplusplus
+#    ifdef __cplusplus
+#        if __cplusplus >= 201400L || _MSVC_LANG >= 201400L
+#            define constexpr14 constexpr
+#        else
+#            define constexpr14
+#        endif
+#    endif  // __cplusplus
 
 
 // STEPOVER is for trivial little glue functions that are annoying to step into in the debugger
@@ -163,11 +149,11 @@
 // or slice constructors. Suppressing debug info for those functions means the debugger
 // will continue through them when stepping in.
 // (It probably also makes the debug-symbol file smaller.)
-#if __has_attribute(nodebug)
-    #define STEPOVER __attribute((nodebug))
-#else
-    #define STEPOVER
-#endif
+#    if __has_attribute(nodebug)
+#        define STEPOVER __attribute((nodebug))
+#    else
+#        define STEPOVER
+#    endif
 
 
 // Note: Code below adapted from libmdbx source code.
@@ -175,68 +161,68 @@
 // `__optimize` is used by the macros below -- you should probably not use it directly, instead
 // use `__hot` or `__cold`. It applies a specific compiler optimization level to a function,
 // e.g. __optimize("O3") or __optimize("Os"). Has no effect in an unoptimized build.
-#ifndef __optimize
-#   if defined(__OPTIMIZE__)
-#       if defined(__clang__) && !__has_attribute(__optimize__)
-#           define __optimize(ops)
-#       elif defined(__GNUC__) || __has_attribute(__optimize__)
-#           define __optimize(ops) __attribute__((__optimize__(ops)))
-#       else
-#           define __optimize(ops)
-#       endif
-#   else
-#           define __optimize(ops)
-#   endif
-#endif /* __optimize */
+#    ifndef __optimize
+#        if defined(__OPTIMIZE__)
+#            if defined(__clang__) && !__has_attribute(__optimize__)
+#                define __optimize(ops)
+#            elif defined(__GNUC__) || __has_attribute(__optimize__)
+#                define __optimize(ops) __attribute__((__optimize__(ops)))
+#            else
+#                define __optimize(ops)
+#            endif
+#        else
+#            define __optimize(ops)
+#        endif
+#    endif /* __optimize */
 
-#if defined(__clang__)
-    #define HOTLEVEL "Ofast"
-    #define COLDLEVEL "Oz"
-#else
-    #define HOTLEVEL "O3"
-    #define COLDLEVEL "Os"
-#endif
+#    if defined(__clang__)
+#        define HOTLEVEL  "Ofast"
+#        define COLDLEVEL "Oz"
+#    else
+#        define HOTLEVEL  "O3"
+#        define COLDLEVEL "Os"
+#    endif
 
 // `__hot` marks a function as being a hot-spot. Optimizes it for speed and may move it to a common
 // code section for hot functions. Has no effect in an unoptimized build.
-#ifndef __hot
-#   if defined(__OPTIMIZE__)
-#       if defined(__clang__) && !__has_attribute(__hot__) \
-        && __has_attribute(__section__) && (defined(__linux__) || defined(__gnu_linux__))
-            /* just put frequently used functions in separate section */
-#           define __hot __attribute__((__section__("text.hot"))) __optimize(HOTLEVEL)
-#       elif defined(__GNUC__) || __has_attribute(__hot__)
-#           define __hot __attribute__((__hot__)) __optimize(HOTLEVEL)
-#       else
-#           define __hot  __optimize(HOTLEVEL)
-#       endif
-#   else
-#       define __hot
-#   endif
-#endif /* __hot */
+#    ifndef __hot
+#        if defined(__OPTIMIZE__)
+#            if defined(__clang__) && !__has_attribute(__hot__) && __has_attribute(__section__)                        \
+                    && (defined(__linux__) || defined(__gnu_linux__))
+/* just put frequently used functions in separate section */
+#                define __hot __attribute__((__section__("text.hot"))) __optimize(HOTLEVEL)
+#            elif defined(__GNUC__) || __has_attribute(__hot__)
+#                define __hot __attribute__((__hot__)) __optimize(HOTLEVEL)
+#            else
+#                define __hot __optimize(HOTLEVEL)
+#            endif
+#        else
+#            define __hot
+#        endif
+#    endif /* __hot */
 
 // `__cold` marks a function as being rarely used (e.g. error handling.) Optimizes it for size and
 // moves it to a common code section for cold functions. Has no effect in an unoptimized build.
-#ifndef __cold
-#   if defined(__OPTIMIZE__)
-#       if defined(__clang__) && !__has_attribute(__cold__) \
-        && __has_attribute(__section__) && (defined(__linux__) || defined(__gnu_linux__))
-            /* just put infrequently used functions in separate section */
-#           define __cold __attribute__((__section__("text.unlikely"))) __optimize(COLDLEVEL)
-#       elif defined(__GNUC__) || __has_attribute(__cold__)
-#           define __cold __attribute__((__cold__)) __optimize(COLDLEVEL)
-#       else
-#           define __cold __optimize(COLDLEVEL)
-#       endif
-#   else
-#       define __cold
-#   endif
-#endif /* __cold */
+#    ifndef __cold
+#        if defined(__OPTIMIZE__)
+#            if defined(__clang__) && !__has_attribute(__cold__) && __has_attribute(__section__)                       \
+                    && (defined(__linux__) || defined(__gnu_linux__))
+/* just put infrequently used functions in separate section */
+#                define __cold __attribute__((__section__("text.unlikely"))) __optimize(COLDLEVEL)
+#            elif defined(__GNUC__) || __has_attribute(__cold__)
+#                define __cold __attribute__((__cold__)) __optimize(COLDLEVEL)
+#            else
+#                define __cold __optimize(COLDLEVEL)
+#            endif
+#        else
+#            define __cold
+#        endif
+#    endif /* __cold */
 
 
-#ifndef _MSC_VER
-    #define WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) 0
-#endif
+#    ifndef _MSC_VER
+#        define WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) 0
+#    endif
 
 // On Windows, FLEECE_PUBLIC marks symbols as being exported from the shared library.
 // However, this is not the whole list of things that are exported.  The API methods
@@ -244,22 +230,22 @@
 // initialized global variables, so those need to be marked (both in the header and
 // implementation) with FLEECE_PUBLIC.  See kFLNullValue below and in Fleece.cc
 // for an example.
-#if defined(_MSC_VER)
-#ifdef FLEECE_EXPORTS
-#define FLEECE_PUBLIC __declspec(dllexport)
-#else
-#define FLEECE_PUBLIC __declspec(dllimport)
-#endif
-#else
-#define FLEECE_PUBLIC __attribute__((visibility("default")))
-#endif
+#    if defined(_MSC_VER)
+#        ifdef FLEECE_EXPORTS
+#            define FLEECE_PUBLIC __declspec(dllexport)
+#        else
+#            define FLEECE_PUBLIC __declspec(dllimport)
+#        endif
+#    else
+#        define FLEECE_PUBLIC __attribute__((visibility("default")))
+#    endif
 
-#ifdef __cplusplus
-    #define FLAPI noexcept
-#else
-    #define FLAPI
-#endif
+#    ifdef __cplusplus
+#        define FLAPI noexcept
+#    else
+#        define FLAPI
+#    endif
 
-#else // _FLEECE_COMPILER_SUPPORT_H
-#warn "Compiler is not honoring #pragma once"
+#else  // _FLEECE_COMPILER_SUPPORT_H
+#    warn "Compiler is not honoring #pragma once"
 #endif

--- a/API/fleece/slice.hh
+++ b/API/fleece/slice.hh
@@ -12,74 +12,73 @@
 
 #pragma once
 #ifndef _FLEECE_SLICE_HH
-#define _FLEECE_SLICE_HH
+#    define _FLEECE_SLICE_HH
 
-#include "FLSlice.h"
-#include <algorithm>            // for std::min()
-#include <stddef.h>
-#include <stdlib.h>
-#include <stdio.h>              // for fputs()
-#include <string.h>             // for memcpy(), memcmp()
-#include <string>
+#    include "FLSlice.h"
+#    include <algorithm>  // for std::min()
+#    include <stddef.h>
+#    include <stdlib.h>
+#    include <stdio.h>   // for fputs()
+#    include <string.h>  // for memcpy(), memcmp()
+#    include <string>
 
-#ifndef assert
-#   include <assert.h>
-#endif
-#   ifndef assert_precondition
-#   define assert_precondition(e) assert(e)
-#endif
+#    ifndef assert
+#        include <assert.h>
+#    endif
+#    ifndef assert_precondition
+#        define assert_precondition(e) assert(e)
+#    endif
 
-#ifdef __APPLE__
-    struct __CFString;
-    struct __CFData;
-#   ifdef __OBJC__
-        @class NSData;
-        @class NSString;
-        @class NSMapTable;
-#   endif
-#endif
+#    ifdef __APPLE__
+struct __CFString;
+struct __CFData;
+#        ifdef __OBJC__
+@class NSData;
+@class NSString;
+@class NSMapTable;
+#        endif
+#    endif
 
 // Figure out whether and how string_view is available
-#ifdef __has_include
-#   if __has_include(<string_view>)
-#       include <string_view>
-#       define SLICE_SUPPORTS_STRING_VIEW
-#   endif
-#endif
+#    ifdef __has_include
+#        if __has_include(<string_view> )
+#            include <string_view>
+#            define SLICE_SUPPORTS_STRING_VIEW
+#        endif
+#    endif
 
 
 // Utility for using slice with printf-style formatting.
 // Use "%.*" in the format string; then for the corresponding argument put FMTSLICE(theslice).
 // NOTE: The argument S will be evaluated twice.
-#define FMTSLICE(S)    (int)(S).size, (const char*)(S).buf
+#    define FMTSLICE(S) (int)(S).size, (const char*)(S).buf
 
 
 FL_ASSUME_NONNULL_BEGIN
-
 
 namespace fleece {
     struct slice;
     struct alloc_slice;
     struct nullslice_t;
 
-#ifdef SLICE_SUPPORTS_STRING_VIEW
-    using string_view = std::string_view; // create typedef with correct namespace
-#endif
+#    ifdef SLICE_SUPPORTS_STRING_VIEW
+    using string_view = std::string_view;  // create typedef with correct namespace
+#    endif
 
-#ifdef __APPLE__
-    using CFStringRef = const struct ::__CFString *;
-    using CFDataRef   = const struct ::__CFData *;
-#endif
-    
+#    ifdef __APPLE__
+    using CFStringRef = const struct ::__CFString*;
+    using CFDataRef   = const struct ::__CFData*;
+#    endif
+
     /** Adds a byte offset to a pointer. */
     template <typename T>
-    FLCONST constexpr14 inline const T* FL_NONNULL offsetby(const T * FL_NONNULL t, ptrdiff_t offset) noexcept {
+    FLCONST constexpr14 inline const T* FL_NONNULL offsetby(const T* FL_NONNULL t, ptrdiff_t offset) noexcept {
         return (const T*)((uint8_t*)t + offset);
     }
 
     /** Adds a byte offset to a pointer. */
     template <typename T>
-    FLCONST constexpr14 inline T* FL_NONNULL offsetby(T * FL_NONNULL t, ptrdiff_t offset) noexcept {
+    FLCONST constexpr14 inline T* FL_NONNULL offsetby(T* FL_NONNULL t, ptrdiff_t offset) noexcept {
         return (T*)((uint8_t*)t + offset);
     }
 
@@ -89,13 +88,9 @@ namespace fleece {
     }
 
     /** Subtracts the 2nd pointer from the 1st, returning the difference in addresses. */
-    FLCONST constexpr inline ptrdiff_t pointerDiff(const void* a, const void* b) noexcept {
-        return _pointerDiff(a, b);
-    }
+    FLCONST constexpr inline ptrdiff_t pointerDiff(const void* a, const void* b) noexcept { return _pointerDiff(a, b); }
 
-
-#pragma mark - PURE_SLICE:
-
+#    pragma mark - PURE_SLICE:
 
     /** Abstract superclass of `slice` and `alloc_slice`.
         A simple pointer to a range of memory: `size` bytes starting at address `buf`.
@@ -114,143 +109,160 @@ namespace fleece {
           methods that allow writes. */
     struct pure_slice {
         const void* FL_NULLABLE const buf;
-        size_t                  const size;
+        size_t const                  size;
 
-        pure_slice(const pure_slice &) noexcept = default;
+        pure_slice(const pure_slice&) noexcept = default;
+
         /// True if the slice's length is zero.
-        bool empty() const noexcept FLPURE                          {return size == 0;}
+        bool empty() const noexcept FLPURE { return size == 0; }
 
         /// Testing a slice as a bool results in false for nullslice, true for anything else.
-        explicit operator bool() const noexcept FLPURE              {return buf != nullptr;}
+        explicit operator bool() const noexcept FLPURE { return buf != nullptr; }
 
         // These methods allow iterating a slice's bytes with a `for(:)` loop:
-        constexpr const uint8_t* FL_NULLABLE begin() const noexcept FLPURE      {return (uint8_t*)buf;}
-        constexpr const uint8_t* FL_NULLABLE end() const noexcept FLPURE        {return begin() + size;}
+        constexpr const uint8_t* FL_NULLABLE begin() const noexcept FLPURE { return (uint8_t*)buf; }
+
+        constexpr const uint8_t* FL_NULLABLE end() const noexcept FLPURE { return begin() + size; }
 
         /// Returns true if the address is within this slice or equal to its \ref end.
-        inline bool validAddress(const void * FL_NULLABLE addr) const noexcept FLPURE;
+        inline bool validAddress(const void* FL_NULLABLE addr) const noexcept FLPURE;
 
         /// Returns true if the byte at this address is in this slice; does _not_ include \ref end.
-        inline bool containsAddress(const void * FL_NULLABLE addr) const noexcept FLPURE;
+        inline bool containsAddress(const void* FL_NULLABLE addr) const noexcept FLPURE;
 
         /// Returns true if the given slice is a subset of me.
         inline bool containsAddressRange(pure_slice) const noexcept FLPURE;
 
         const void* offset(size_t o) const noexcept FLPURE;
-        size_t offsetOf(const void* ptr) const noexcept FLPURE;
+        size_t      offsetOf(const void* ptr) const noexcept FLPURE;
 
         inline const uint8_t& operator[](size_t i) const noexcept FLPURE;
-        inline slice operator()(size_t i, size_t n) const noexcept FLPURE;
+        inline slice          operator()(size_t i, size_t n) const noexcept FLPURE;
 
         inline slice upTo(const void* pos) const noexcept FLPURE;
         inline slice from(const void* pos) const noexcept FLPURE;
         inline slice upTo(size_t offset) const noexcept FLPURE;
         inline slice from(size_t offset) const noexcept FLPURE;
 
-        inline bool containsBytes(pure_slice bytes) const noexcept FLPURE;
-        inline slice find(pure_slice target) const noexcept FLPURE;
+        inline bool                       containsBytes(pure_slice bytes) const noexcept FLPURE;
+        inline slice                      find(pure_slice target) const noexcept FLPURE;
         inline const uint8_t* FL_NULLABLE findByte(uint8_t b) const FLPURE;
         inline const uint8_t* FL_NULLABLE findByteOrEnd(uint8_t byte) const noexcept FLPURE;
         inline const uint8_t* FL_NULLABLE findAnyByteOf(pure_slice targetBytes) const noexcept FLPURE;
         inline const uint8_t* FL_NULLABLE findByteNotIn(pure_slice targetBytes) const noexcept FLPURE;
 
-        inline int compare(pure_slice s) const noexcept FLPURE    {return FLSlice_Compare(*this,s);}
-        inline int caseEquivalentCompare(pure_slice) const noexcept FLPURE;
+        inline int compare(pure_slice s) const noexcept FLPURE { return FLSlice_Compare(*this, s); }
+
+        inline int  caseEquivalentCompare(pure_slice) const noexcept FLPURE;
         inline bool caseEquivalent(pure_slice) const noexcept FLPURE;
 
         // Relational operators, implemented with FLSlice_Equal and compare():
 
-        bool operator==(const pure_slice &s) const noexcept FLPURE  {return FLSlice_Equal(*this,s);}
-        bool operator!=(const pure_slice &s) const noexcept FLPURE  {return !(*this == s);}
-        bool operator<(pure_slice s) const noexcept FLPURE          {return compare(s) < 0;}
-        bool operator>(pure_slice s) const noexcept FLPURE          {return compare(s) > 0;}
-        bool operator<=(pure_slice s) const noexcept FLPURE         {return compare(s) <= 0;}
-        bool operator>=(pure_slice s) const noexcept FLPURE         {return compare(s) >= 0;}
+        bool operator==(const pure_slice& s) const noexcept FLPURE { return FLSlice_Equal(*this, s); }
+
+        bool operator!=(const pure_slice& s) const noexcept FLPURE { return !(*this == s); }
+
+        bool operator<(pure_slice s) const noexcept FLPURE { return compare(s) < 0; }
+
+        bool operator>(pure_slice s) const noexcept FLPURE { return compare(s) > 0; }
+
+        bool operator<=(pure_slice s) const noexcept FLPURE { return compare(s) <= 0; }
+
+        bool operator>=(pure_slice s) const noexcept FLPURE { return compare(s) >= 0; }
 
         inline bool hasPrefix(pure_slice) const noexcept FLPURE;
         inline bool hasSuffix(pure_slice) const noexcept FLPURE;
-        bool hasPrefix(uint8_t b) const noexcept FLPURE   {return size > 0 && (*this)[0] == b;}
-        bool hasSuffix(uint8_t b) const noexcept FLPURE   {return size > 0 && (*this)[size-1] == b;}
+
+        bool hasPrefix(uint8_t b) const noexcept FLPURE { return size > 0 && (*this)[0] == b; }
+
+        bool hasSuffix(uint8_t b) const noexcept FLPURE { return size > 0 && (*this)[size - 1] == b; }
 
         /** Computes a 32-bit non-cryptographic hash of the slice's contents. */
-        uint32_t hash() const noexcept FLPURE       {return FLSlice_Hash(*this);}
+        uint32_t hash() const noexcept FLPURE { return FLSlice_Hash(*this); }
 
         /// Copies my contents to memory starting at `dst`, using `memcpy`.
-        void copyTo(void *dst) const noexcept       {FLMemCpy(dst, buf, size);}
+        void copyTo(void* dst) const noexcept { FLMemCpy(dst, buf, size); }
 
         /// Returns new malloc'ed slice containing same data. Call free() on it when done.
         inline slice copy() const;
 
         // String conversions:
 
-        explicit operator std::string() const       {return std::string((const char*)buf, size);}
-        std::string asString() const                {return (std::string)*this;}
+        explicit operator std::string() const { return std::string((const char*)buf, size); }
+
+        std::string asString() const { return (std::string) * this; }
 
         std::string hexString() const;
 
         /** Copies into a C string buffer of the given size. Result is always NUL-terminated and
             will not overflow the buffer. Returns false if the slice was truncated. */
-        inline bool toCString(char *buf, size_t bufSize) const noexcept;
+        inline bool toCString(char* buf, size_t bufSize) const noexcept;
 
         // FLSlice interoperability:
-        constexpr operator FLSlice () const noexcept {return {buf, size};}
+        constexpr operator FLSlice() const noexcept { return {buf, size}; }
 
-#ifdef SLICE_SUPPORTS_STRING_VIEW
+#    ifdef SLICE_SUPPORTS_STRING_VIEW
         // std::string_view interoperability:
-        constexpr pure_slice(string_view str) noexcept            :pure_slice(str.data(), str.length()) {}
-        operator string_view() const noexcept STEPOVER {return string_view((const char*)buf, size);}
-#endif
+        constexpr pure_slice(string_view str) noexcept : pure_slice(str.data(), str.length()) {}
 
-#ifdef __APPLE__
+        operator string_view() const noexcept STEPOVER { return string_view((const char*)buf, size); }
+#    endif
+
+#    ifdef __APPLE__
         // Implementations in slice+CoreFoundation.cc and slice+ObjC.mm
         explicit pure_slice(CFDataRef FL_NULLABLE data) noexcept;
         CFStringRef createCFString() const;
-        CFDataRef createCFData() const;
-#   ifdef __OBJC__
+        CFDataRef   createCFData() const;
+#        ifdef __OBJC__
         explicit pure_slice(NSData* FL_NULLABLE data) noexcept;
         NSData* copiedNSData() const;
         /** Creates an NSData using initWithBytesNoCopy and freeWhenDone:NO.
             The data is not copied and does not belong to the NSData object, so make sure it
             remains valid for the lifespan of that object!. */
-        NSData* uncopiedNSData() const;
+        NSData*   uncopiedNSData() const;
         NSString* asNSString() const;
         NSString* asNSString(NSMapTable* FL_NULLABLE sharedStrings) const;
-#   endif
-#endif
+#        endif
+#    endif
 
-        constexpr pure_slice(std::nullptr_t) noexcept             :pure_slice() {}
-        constexpr pure_slice(const char* FL_NULLABLE str) noexcept :buf(str), size(_strlen(str)) {}
-        pure_slice(const std::string& str) noexcept               :buf(&str[0]), size(str.size()) {}
+        constexpr pure_slice(std::nullptr_t) noexcept : pure_slice() {}
+
+        constexpr pure_slice(const char* FL_NULLABLE str) noexcept : buf(str), size(_strlen(str)) {}
+
+        pure_slice(const std::string& str) noexcept : buf(&str[0]), size(str.size()) {}
 
         // Raw memory allocation. These throw std::bad_alloc on failure.
         RETURNS_NONNULL inline static void* newBytes(size_t sz);
-        template <typename T> RETURNS_NONNULL
-            static inline T* FL_NONNULL reallocBytes(T* FL_NULLABLE bytes, size_t newSz);
+        template <typename T>
+        RETURNS_NONNULL static inline T* FL_NONNULL reallocBytes(T* FL_NULLABLE bytes, size_t newSz);
 
-    protected:
-        constexpr pure_slice() noexcept                           :buf(nullptr), size(0) {}
+      protected:
+        constexpr pure_slice() noexcept : buf(nullptr), size(0) {}
+
         inline constexpr pure_slice(const void* FL_NULLABLE b, size_t s) noexcept;
 
-        inline void setBuf(const void *b) noexcept;
+        inline void setBuf(const void* b) noexcept;
         inline void setSize(size_t s) noexcept;
-        inline void set(const void * FL_NULLABLE, size_t) noexcept;
+        inline void set(const void* FL_NULLABLE, size_t) noexcept;
 
         // (Assignment must be custom because `buf` is declared as const/immutable.)
-        pure_slice& operator=(const pure_slice &s) noexcept  {set(s.buf, s.size); return *this;}
+        pure_slice& operator=(const pure_slice& s) noexcept {
+            set(s.buf, s.size);
+            return *this;
+        }
+
         static inline constexpr size_t _strlen(const char* FL_NULLABLE str) noexcept FLPURE;
         // Throws std::bad_alloc, or if exceptions are disabled calls std::terminate()
         [[noreturn]] static void failBadAlloc();
         // Sanity-checks `buf` and `size`
         inline constexpr void checkValidSlice() const;
         // Calls `assert_precondition(validAddress(addr))`, then returns `addr`
-        inline const void* check(const void *addr) const;
+        inline const void* check(const void* addr) const;
         // Calls `assert_precondition(offset <= size)`, then returns `addr`
         inline size_t check(size_t offset) const;
     };
 
-
-#pragma mark - SLICE:
-
+#    pragma mark - SLICE:
 
     /** A simple pointer to a range of memory: `size` bytes starting at address `buf`.
         \warning **No ownership is implied!** Just like a regular pointer, it's the client's
@@ -259,112 +271,144 @@ namespace fleece {
         * `buf` may be NULL, but only if `size` is zero; this is called `nullslice`.
         * `size` may be zero with a non-NULL `buf`; that's called an "empty slice". */
     struct slice : public pure_slice {
-        constexpr slice() noexcept STEPOVER                           :pure_slice() {}
-        constexpr slice(std::nullptr_t) noexcept STEPOVER             :pure_slice() {}
+        constexpr slice() noexcept STEPOVER : pure_slice() {}
+
+        constexpr slice(std::nullptr_t) noexcept STEPOVER : pure_slice() {}
+
         inline constexpr slice(nullslice_t) noexcept STEPOVER;
-        constexpr slice(const void* FL_NULLABLE b, size_t s) noexcept STEPOVER    :pure_slice(b, s) {}
+
+        constexpr slice(const void* FL_NULLABLE b, size_t s) noexcept STEPOVER : pure_slice(b, s) {}
+
         inline constexpr slice(const void* start, const void* end) noexcept STEPOVER;
         inline constexpr slice(const alloc_slice&) noexcept STEPOVER;
 
-        slice(const std::string& str) noexcept STEPOVER               :pure_slice(str) {}
-        constexpr slice(const char* FL_NULLABLE str) noexcept STEPOVER  :pure_slice(str) {}
+        slice(const std::string& str) noexcept STEPOVER : pure_slice(str) {}
 
-        slice& operator= (alloc_slice&&) =delete;   // Disallowed: might lead to ptr to freed buf
-        slice& operator= (const alloc_slice &s) noexcept    {return *this = slice(s);}
-        slice& operator= (std::nullptr_t) noexcept          {set(nullptr, 0); return *this;}
-        inline slice& operator= (nullslice_t) noexcept;
+        constexpr slice(const char* FL_NULLABLE str) noexcept STEPOVER : pure_slice(str) {}
+
+        slice& operator=(alloc_slice&&) = delete;  // Disallowed: might lead to ptr to freed buf
+
+        slice& operator=(const alloc_slice& s) noexcept { return *this = slice(s); }
+
+        slice& operator=(std::nullptr_t) noexcept {
+            set(nullptr, 0);
+            return *this;
+        }
+
+        inline slice& operator=(nullslice_t) noexcept;
 
         /// Sets `size`.
-        void setSize(size_t s) noexcept                     {pure_slice::setSize(s);}
+        void setSize(size_t s) noexcept { pure_slice::setSize(s); }
+
         /// Sets `size`; asserts that the new size is not larger.
         inline void shorten(size_t s);
 
         /// Adjusts `size` so that \ref end returns the given value.
-        void setEnd(const void* e) noexcept         {setSize(pointerDiff(e, buf));}
+        void setEnd(const void* e) noexcept { setSize(pointerDiff(e, buf)); }
+
         /// Sets `buf` without moving the end, adjusting `size` accordingly.
         inline void setStart(const void* s) noexcept;
+
         /// Moves `buf` without moving the end, adjusting `size` accordingly.
-        void moveStart(ptrdiff_t delta) noexcept            {set(offsetby(buf, delta), size - delta);}
+        void moveStart(ptrdiff_t delta) noexcept { set(offsetby(buf, delta), size - delta); }
+
         /// Like \ref moveStart but returns false if the move is illegal.
-        bool checkedMoveStart(size_t delta) noexcept        {if (size<delta) return false;
-                                                             else {moveStart(delta); return true;}}
+        bool checkedMoveStart(size_t delta) noexcept {
+            if ( size < delta ) return false;
+            else {
+                moveStart(delta);
+                return true;
+            }
+        }
+
         // FLSlice interoperability:
-        constexpr slice(const FLSlice &s) noexcept STEPOVER           :pure_slice(s.buf,s.size) { }
-        inline explicit operator FLSliceResult () const noexcept;
-        explicit slice(const FLSliceResult &sr) STEPOVER            :pure_slice(sr.buf, sr.size) { }
-        slice& operator= (FLHeapSlice s) noexcept           {set(s.buf, s.size); return *this;} // disambiguation
+        constexpr slice(const FLSlice& s) noexcept STEPOVER : pure_slice(s.buf, s.size) {}
 
-#ifdef SLICE_SUPPORTS_STRING_VIEW
-        constexpr slice(string_view str) noexcept STEPOVER            :pure_slice(str) {}
-#endif
+        inline explicit operator FLSliceResult() const noexcept;
 
-#ifdef __APPLE__
-        explicit slice(CFDataRef data) noexcept                       :pure_slice(data) {}
-#   ifdef __OBJC__
-        explicit slice(NSData* data) noexcept                         :pure_slice(data) {}
-#   endif
-#endif
+        explicit slice(const FLSliceResult& sr) STEPOVER : pure_slice(sr.buf, sr.size) {}
+
+        slice& operator=(FLHeapSlice s) noexcept {
+            set(s.buf, s.size);
+            return *this;
+        }  // disambiguation
+
+#    ifdef SLICE_SUPPORTS_STRING_VIEW
+        constexpr slice(string_view str) noexcept STEPOVER : pure_slice(str) {}
+#    endif
+
+#    ifdef __APPLE__
+        explicit slice(CFDataRef data) noexcept : pure_slice(data) {}
+#        ifdef __OBJC__
+        explicit slice(NSData* data) noexcept : pure_slice(data) {}
+#        endif
+#    endif
     };
-
 
     /** An awkwardly unrelated struct for when the bytes need to be writeable. */
     struct mutable_slice {
         void* FL_NULLABLE buf;
-        size_t size;
+        size_t            size;
 
-        constexpr mutable_slice() noexcept                      :buf(nullptr), size(0) {}
-        explicit constexpr mutable_slice(pure_slice s) noexcept :buf((void*)s.buf), size(s.size) {}
-        constexpr mutable_slice(void* FL_NULLABLE b, size_t s) noexcept     :buf(b), size(s) {}
-        constexpr mutable_slice(void* b, void* e) noexcept      :buf(b),
-                                                                size(pointerDiff(e, b)) {}
+        constexpr mutable_slice() noexcept : buf(nullptr), size(0) {}
 
-        operator slice() const noexcept                         {return slice(buf, size);}
+        explicit constexpr mutable_slice(pure_slice s) noexcept : buf((void*)s.buf), size(s.size) {}
+
+        constexpr mutable_slice(void* FL_NULLABLE b, size_t s) noexcept : buf(b), size(s) {}
+
+        constexpr mutable_slice(void* b, void* e) noexcept : buf(b), size(pointerDiff(e, b)) {}
+
+        operator slice() const noexcept { return slice(buf, size); }
 
         /// Securely zeroes the bytes; use this for passwords or encryption keys.
-        void wipe() noexcept                                   {if (size) FL_WipeMemory(buf, size);}
+        void wipe() noexcept {
+            if ( size ) FL_WipeMemory(buf, size);
+        }
     };
-
 
     struct nullslice_t : public slice {
-        constexpr nullslice_t() noexcept   :slice() {}
+        constexpr nullslice_t() noexcept : slice() {}
     };
-    
+
     /** A null/empty slice. (You can also use `nullptr` for this purpose.) */
     constexpr nullslice_t nullslice;
 
-
     /** Literal syntax for slices: `"foo"_sl` */
-    inline constexpr slice operator "" _sl (const char *str, size_t length) noexcept {
-        return slice(str, length);
-    }
+    inline constexpr slice operator"" _sl(const char* str, size_t length) noexcept { return slice(str, length); }
 
-
-#pragma mark - ALLOC_SLICE:
+#    pragma mark - ALLOC_SLICE:
 
     /** A \ref slice that owns a heap-allocated, ref-counted block of memory. */
     struct [[nodiscard]] alloc_slice : public pure_slice {
-        constexpr alloc_slice() noexcept STEPOVER                             {}
-        constexpr alloc_slice(std::nullptr_t) noexcept STEPOVER               {}
-        constexpr alloc_slice(nullslice_t) noexcept STEPOVER                  {}
+        constexpr alloc_slice() noexcept STEPOVER {}
+
+        constexpr alloc_slice(std::nullptr_t) noexcept STEPOVER {}
+
+        constexpr alloc_slice(nullslice_t) noexcept STEPOVER {}
 
         inline explicit alloc_slice(size_t sz) STEPOVER;
 
-        alloc_slice(const void* FL_NULLABLE b, size_t s)    :alloc_slice(slice(b, s)) {}
-        alloc_slice(const void* start,
-                    const void* end)                        :alloc_slice(slice(start, end)) {}
-        explicit alloc_slice(const char* FL_NULLABLE str)   :alloc_slice(slice(str)) {}
-        explicit alloc_slice(const std::string &str)        :alloc_slice(slice(str)) {}
+        alloc_slice(const void* FL_NULLABLE b, size_t s) : alloc_slice(slice(b, s)) {}
+
+        alloc_slice(const void* start, const void* end) : alloc_slice(slice(start, end)) {}
+
+        explicit alloc_slice(const char* FL_NULLABLE str) : alloc_slice(slice(str)) {}
+
+        explicit alloc_slice(const std::string& str) : alloc_slice(slice(str)) {}
 
         inline explicit alloc_slice(pure_slice s) STEPOVER;
-        explicit alloc_slice(FLSlice s)                     :alloc_slice(s.buf, s.size) { }
-        alloc_slice(const alloc_slice &s) noexcept STEPOVER     :pure_slice(s) {retain();}
-        alloc_slice(alloc_slice&& s) noexcept STEPOVER          :pure_slice(s) {s.set(nullptr, 0);}
 
-        ~alloc_slice() STEPOVER                                 {_FLBuf_Release(buf);}
+        explicit alloc_slice(FLSlice s) : alloc_slice(s.buf, s.size) {}
+
+        alloc_slice(const alloc_slice& s) noexcept STEPOVER : pure_slice(s) { retain(); }
+
+        alloc_slice(alloc_slice&& s) noexcept STEPOVER : pure_slice(s) { s.set(nullptr, 0); }
+
+        ~alloc_slice() STEPOVER { _FLBuf_Release(buf); }
 
         inline alloc_slice& operator=(const alloc_slice&) noexcept STEPOVER;
 
-        alloc_slice& operator=(alloc_slice&& s) noexcept  {
+        alloc_slice& operator=(alloc_slice&& s) noexcept {
             std::swap((slice&)*this, (slice&)s);
             return *this;
         }
@@ -373,18 +417,35 @@ namespace fleece {
             data. This allows the contents of the alloc_slice to be used as a C string. */
         inline static alloc_slice nullPaddedString(pure_slice);
 
-        alloc_slice& operator= (pure_slice s)               {return *this = alloc_slice(s);}
-        alloc_slice& operator= (FLSlice s)                  {return operator=(slice(s.buf,s.size));}
-        alloc_slice& operator= (std::nullptr_t) noexcept    {reset(); return *this;}
+        alloc_slice& operator=(pure_slice s) { return *this = alloc_slice(s); }
+
+        alloc_slice& operator=(FLSlice s) { return operator=(slice(s.buf, s.size)); }
+
+        alloc_slice& operator=(std::nullptr_t) noexcept {
+            reset();
+            return *this;
+        }
 
         // disambiguation:
-        alloc_slice& operator= (const char *str)            {*this = (slice)str; return *this;}
-        alloc_slice& operator= (const std::string &str)     {*this = (slice)str; return *this;}
+        alloc_slice& operator=(const char* str) {
+            *this = (slice)str;
+            return *this;
+        }
+
+        alloc_slice& operator=(const std::string& str) {
+            *this = (slice)str;
+            return *this;
+        }
 
         /// Releases and clears; same as assigning `nullslice`.
-        void reset() noexcept                               {release(); assignFrom(nullslice);}
+        void reset() noexcept {
+            release();
+            assignFrom(nullslice);
+        }
+
         /// Resets to an uninitialized block of the given size.
-        void reset(size_t sz)                               {*this = alloc_slice(sz);}
+        void reset(size_t sz) { *this = alloc_slice(sz); }
+
         /// Changes the size of the block by re-allocating. This changes `buf`!
         inline void resize(size_t newSize);
         /// Grows the block and appends data to the end.
@@ -393,127 +454,151 @@ namespace fleece {
         inline void shorten(size_t s);
 
         // FLSliceResult interoperability:
-        explicit alloc_slice(const FLSliceResult &s) noexcept STEPOVER :pure_slice(s.buf, s.size) {retain();}
-        alloc_slice(FLSliceResult &&sr) noexcept STEPOVER  :pure_slice(sr.buf, sr.size) { }
-        explicit operator FLSliceResult () & noexcept       {retain(); return {(void*)buf, size};}
-        explicit operator FLSliceResult () && noexcept      {FLSliceResult r {(void*)buf, size};
-                                                             set(nullptr, 0); return r;}
-        alloc_slice& operator= (FLSliceResult &&sr) noexcept {release(); set(sr.buf, sr.size);
-                                                              return *this;}
+        explicit alloc_slice(const FLSliceResult& s) noexcept STEPOVER : pure_slice(s.buf, s.size) { retain(); }
+
+        alloc_slice(FLSliceResult&& sr) noexcept STEPOVER : pure_slice(sr.buf, sr.size) {}
+
+        explicit operator FLSliceResult() & noexcept {
+            retain();
+            return {(void*)buf, size};
+        }
+
+        explicit operator FLSliceResult() && noexcept {
+            FLSliceResult r{(void*)buf, size};
+            set(nullptr, 0);
+            return r;
+        }
+
+        alloc_slice& operator=(FLSliceResult&& sr) noexcept {
+            release();
+            set(sr.buf, sr.size);
+            return *this;
+        }
+
         // FLHeapSlice interoperability:
-        alloc_slice(FLHeapSlice s) noexcept STEPOVER        :pure_slice(s.buf, s.size) {retain();}
-        alloc_slice& operator= (FLHeapSlice) noexcept;
-        operator FLHeapSlice () const noexcept              {return {buf, size};}
+        alloc_slice(FLHeapSlice s) noexcept STEPOVER : pure_slice(s.buf, s.size) { retain(); }
+
+        alloc_slice& operator=(FLHeapSlice) noexcept;
+
+        operator FLHeapSlice() const noexcept { return {buf, size}; }
 
         // std::string_view interoperability:
-#ifdef SLICE_SUPPORTS_STRING_VIEW
-        explicit alloc_slice(string_view str) STEPOVER          :alloc_slice(slice(str)) {}
-        alloc_slice& operator=(string_view str)             {*this = (slice)str; return *this;}
-#endif
+#    ifdef SLICE_SUPPORTS_STRING_VIEW
+        explicit alloc_slice(string_view str) STEPOVER : alloc_slice(slice(str)) {}
+
+        alloc_slice& operator=(string_view str) {
+            *this = (slice)str;
+            return *this;
+        }
+#    endif
 
         // CFData / CFString / NSData / NSString interoperability:
-#ifdef __APPLE__
+#    ifdef __APPLE__
         // Implementations in slice+CoreFoundation.cc and slice+ObjC.mm
         explicit alloc_slice(CFDataRef FL_NULLABLE);
         explicit alloc_slice(CFStringRef FL_NULLABLE);
         /** Creates a CFDataDataRef. The data is not copied: the CFDataRef points to the same
             bytes as this alloc_slice, which is retained until the CFDataRef is freed. */
         [[nodiscard]] CFDataRef createCFData() const;
-#   ifdef __OBJC__
+#        ifdef __OBJC__
         explicit alloc_slice(NSData* FL_NULLABLE data);
         /** Creates an NSData using initWithBytesNoCopy and a deallocator that releases this
             alloc_slice. The data is not copied and does not belong to the NSData object. */
         NSData* uncopiedNSData() const;
-#   endif
-#endif
+#        endif
+#    endif
 
         // Manual ref-count management. Use with extreme caution! You probably don't need this.
-        alloc_slice& retain() noexcept                      {_FLBuf_Retain(buf); return *this;}
-        inline void release() noexcept                      {_FLBuf_Release(buf);}
-        static void retain(slice s) noexcept                {static_cast<alloc_slice &>(static_cast<pure_slice &>(s)).retain();}
-        static void release(slice s) noexcept               {static_cast<alloc_slice &>(static_cast<pure_slice &>(s)).release();}
+        alloc_slice& retain() noexcept {
+            _FLBuf_Retain(buf);
+            return *this;
+        }
 
-    private:
-        void assignFrom(pure_slice s)                       {set(s.buf, s.size);}
+        inline void release() noexcept { _FLBuf_Release(buf); }
+
+        static void retain(slice s) noexcept { static_cast<alloc_slice&>(static_cast<pure_slice&>(s)).retain(); }
+
+        static void release(slice s) noexcept { static_cast<alloc_slice&>(static_cast<pure_slice&>(s)).release(); }
+
+      private:
+        void assignFrom(pure_slice s) { set(s.buf, s.size); }
     };
-
-
 
     /** A slice whose `buf` may not be NULL. For use as a parameter type. */
     struct slice_NONNULL : public slice {
-        constexpr slice_NONNULL(const void* b, size_t s)            :slice(b, s) {}
-        constexpr slice_NONNULL(slice s)                            :slice_NONNULL(s.buf, s.size) {}
-        constexpr slice_NONNULL(FLSlice s)                          :slice_NONNULL(s.buf,s.size) {}
-        constexpr slice_NONNULL(const char *str NONNULL)            :slice(str) {}
-        slice_NONNULL(alloc_slice s)                                :slice_NONNULL(s.buf,s.size) {}
-        slice_NONNULL(const std::string &str)               :slice_NONNULL(str.data(),str.size()) {}
-#ifdef SLICE_SUPPORTS_STRING_VIEW
-        slice_NONNULL(string_view str)                      :slice_NONNULL(str.data(),str.size()) {}
-#endif
-        slice_NONNULL(std::nullptr_t) =delete;
-        slice_NONNULL(nullslice_t) =delete;
+        constexpr slice_NONNULL(const void* b, size_t s) : slice(b, s) {}
+
+        constexpr slice_NONNULL(slice s) : slice_NONNULL(s.buf, s.size) {}
+
+        constexpr slice_NONNULL(FLSlice s) : slice_NONNULL(s.buf, s.size) {}
+
+        constexpr slice_NONNULL(const char* FL_NONNULL str) : slice(str) {}
+
+        slice_NONNULL(alloc_slice s) : slice_NONNULL(s.buf, s.size) {}
+
+        slice_NONNULL(const std::string& str) : slice_NONNULL(str.data(), str.size()) {}
+#    ifdef SLICE_SUPPORTS_STRING_VIEW
+        slice_NONNULL(string_view str) : slice_NONNULL(str.data(), str.size()) {}
+#    endif
+        slice_NONNULL(std::nullptr_t) = delete;
+        slice_NONNULL(nullslice_t)    = delete;
     };
 
 
-
-#ifdef __APPLE__
+#    ifdef __APPLE__
     /** A slice holding the UTF-8 data of an NSString. If possible, it gets a pointer directly into
         the NSString in O(1) time -- so don't modify or release the NSString while this is in scope.
         Alternatively it will copy the string's UTF-8 into a small internal buffer, or allocate
         a larger buffer on the heap (and free it in its destructor.) */
     struct nsstring_slice : public slice {
         nsstring_slice(CFStringRef FL_NULLABLE);
-#   ifdef __OBJC__
-        nsstring_slice(NSString* FL_NULLABLE str)   :nsstring_slice((__bridge CFStringRef)str) { }
-#   endif
+#        ifdef __OBJC__
+        nsstring_slice(NSString* FL_NULLABLE str) : nsstring_slice((__bridge CFStringRef)str) {}
+#        endif
         ~nsstring_slice();
-    private:
+
+      private:
         long getBytes(CFStringRef, long lengthInChars);
         char _local[127];
         bool _needsFree;
     };
-#endif
+#    endif
 
 
     /** Functor class for hashing the contents of a slice.
         \note The below declarations of `std::hash` usually make it unnecessary to use this. */
     struct sliceHash {
-        std::size_t operator() (pure_slice const& s) const {return s.hash();}
+        std::size_t operator()(pure_slice const& s) const { return s.hash(); }
     };
 
-
-
-#pragma mark - PURE_SLICE METHOD BODIES:
+#    pragma mark - PURE_SLICE METHOD BODIES:
 
 
     // like strlen but can run at compile time
-#if __cplusplus >= 201400L || _MSVC_LANG >= 201400L
+#    if __cplusplus >= 201400L || _MSVC_LANG >= 201400L
     inline constexpr size_t pure_slice::_strlen(const char* FL_NULLABLE str) noexcept {
-        if (!str)
-            return 0;
+        if ( !str ) return 0;
         auto c = str;
-        while (*c) ++c;
+        while ( *c ) ++c;
         return c - str;
     }
-#else
+#    else
     // (In C++11, constexpr functions couldn't contain loops; use (tail-)recursion instead)
     inline constexpr size_t pure_slice::_strlen(const char* FL_NULLABLE str) noexcept {
         return str ? _strlen(str, 0) : 0;
     }
-    inline constexpr size_t pure_slice::_strlen(const char *str, size_t n) noexcept {
+
+    inline constexpr size_t pure_slice::_strlen(const char* str, size_t n) noexcept {
         return *str ? _strlen(str + 1, n + 1) : n;
     }
-#endif
+#    endif
 
 
-    inline constexpr pure_slice::pure_slice(const void* FL_NULLABLE b, size_t s) noexcept
-    :buf(b), size(s)
-    {
+    inline constexpr pure_slice::pure_slice(const void* FL_NULLABLE b, size_t s) noexcept : buf(b), size(s) {
         checkValidSlice();
     }
 
-
-    inline void pure_slice::setBuf(const void *b) noexcept {
+    inline void pure_slice::setBuf(const void* b) noexcept {
         const_cast<const void*&>(buf) = b;
         checkValidSlice();
     }
@@ -523,36 +608,31 @@ namespace fleece {
         checkValidSlice();
     }
 
-    inline void pure_slice::set(const void * FL_NULLABLE b, size_t s) noexcept {
+    inline void pure_slice::set(const void* FL_NULLABLE b, size_t s) noexcept {
         const_cast<const void*&>(buf) = b;
-        const_cast<size_t&>(size) = s;
+        const_cast<size_t&>(size)     = s;
         checkValidSlice();
     }
 
-
-    inline bool pure_slice::validAddress(const void * FL_NULLABLE addr) const noexcept {
+    inline bool pure_slice::validAddress(const void* FL_NULLABLE addr) const noexcept {
         // Note: unsigned comparison handles case when addr < buf
         return size_t(_pointerDiff(addr, buf)) <= size;
     }
 
-
-    inline bool pure_slice::containsAddress(const void * FL_NULLABLE addr) const noexcept {
+    inline bool pure_slice::containsAddress(const void* FL_NULLABLE addr) const noexcept {
         return size_t(_pointerDiff(addr, buf)) < size;
     }
-
 
     inline bool pure_slice::containsAddressRange(pure_slice s) const noexcept {
         return s.buf >= buf && s.end() <= end();
     }
 
-
     inline constexpr void pure_slice::checkValidSlice() const {
         assert_precondition(buf != nullptr || size == 0);
-        assert_precondition(size < (1ull << (8*sizeof(void*)-1)));   // check accidental negative size
+        assert_precondition(size < (1ull << (8 * sizeof(void*) - 1)));  // check accidental negative size
     }
 
-
-    inline const void* pure_slice::check(const void *addr) const {
+    inline const void* pure_slice::check(const void* addr) const {
         assert_precondition(validAddress(addr));
         return addr;
     }
@@ -562,56 +642,42 @@ namespace fleece {
         return offset;
     }
 
+    inline const void* pure_slice::offset(size_t o) const noexcept { return (uint8_t*)buf + check(o); }
 
-    inline const void* pure_slice::offset(size_t o) const noexcept {
-        return (uint8_t*)buf + check(o);
-    }
-
-    inline size_t pure_slice::offsetOf(const void* ptr NONNULL) const noexcept {
+    inline size_t pure_slice::offsetOf(const void* FL_NONNULL ptr) const noexcept {
         return pointerDiff(check(ptr), buf);
     }
 
+    inline slice pure_slice::upTo(const void* pos) const noexcept { return slice(buf, check(pos)); }
 
-    inline slice pure_slice::upTo(const void* pos) const noexcept {
-        return slice(buf, check(pos));
-    }
+    inline slice pure_slice::from(const void* pos) const noexcept { return slice(check(pos), end()); }
 
-    inline slice pure_slice::from(const void* pos) const noexcept {
-        return slice(check(pos), end());
-    }
+    inline slice pure_slice::upTo(size_t off) const noexcept { return slice(buf, check(off)); }
 
-    inline slice pure_slice::upTo(size_t off) const noexcept {
-        return slice(buf, check(off));
-    }
-
-    inline slice pure_slice::from(size_t off) const noexcept {
-        return slice(offset(check(off)), end());
-    }
+    inline slice pure_slice::from(size_t off) const noexcept { return slice(offset(check(off)), end()); }
 
     inline const uint8_t& pure_slice::operator[](size_t off) const noexcept {
         assert_precondition(off < size);
         return ((const uint8_t*)buf)[off];
     }
 
-    inline slice pure_slice::operator()(size_t off, size_t nBytes) const noexcept  {
+    inline slice pure_slice::operator()(size_t off, size_t nBytes) const noexcept {
         assert_precondition(off + nBytes <= size);
         return slice(offset(off), nBytes);
     }
 
-
-    inline bool pure_slice::toCString(char *str, size_t bufSize) const noexcept {
-        size_t n = std::min(size, bufSize-1);
+    inline bool pure_slice::toCString(char* str, size_t bufSize) const noexcept {
+        size_t n = std::min(size, bufSize - 1);
         FLMemCpy(str, buf, n);
         str[n] = 0;
         return n == size;
     }
 
-
     inline std::string pure_slice::hexString() const {
         static const char kDigits[17] = "0123456789abcdef";
-        std::string result;
+        std::string       result;
         result.reserve(2 * size);
-        for (size_t i = 0; i < size; i++) {
+        for ( size_t i = 0; i < size; i++ ) {
             uint8_t byte = (*this)[(unsigned)i];
             result += kDigits[byte >> 4];
             result += kDigits[byte & 0xF];
@@ -619,213 +685,151 @@ namespace fleece {
         return result;
     }
 
+#    pragma mark COMPARISON & FIND:
 
-#pragma mark  COMPARISON & FIND:
-
-
-    __hot
-    inline int pure_slice::caseEquivalentCompare(pure_slice b) const noexcept {
+    __hot inline int pure_slice::caseEquivalentCompare(pure_slice b) const noexcept {
         size_t minSize = std::min(size, b.size);
-        for (size_t i = 0; i < minSize; i++) {
-            if ((*this)[i] != b[i]) {
+        for ( size_t i = 0; i < minSize; i++ ) {
+            if ( (*this)[i] != b[i] ) {
                 int cmp = ::tolower((*this)[i]) - ::tolower(b[i]);
-                if (cmp != 0)
-                    return cmp;
+                if ( cmp != 0 ) return cmp;
             }
         }
         return (int)size - (int)b.size;
     }
 
-
-    __hot
-    inline bool pure_slice::caseEquivalent(pure_slice b) const noexcept {
-        if (size != b.size)
-            return false;
-        for (size_t i = 0; i < size; i++)
-            if (::tolower((*this)[i]) != ::tolower(b[i]))
-                return false;
+    __hot inline bool pure_slice::caseEquivalent(pure_slice b) const noexcept {
+        if ( size != b.size ) return false;
+        for ( size_t i = 0; i < size; i++ )
+            if ( ::tolower((*this)[i]) != ::tolower(b[i]) ) return false;
         return true;
     }
 
-
-    __hot
-    inline slice pure_slice::find(pure_slice target) const noexcept {
-        char* src = (char *)buf;
-        char* search = (char *)target.buf;
-        char* found = std::search(src, src + size, search, search + target.size);
-        if(found == src + size) {
-            return nullslice;
-        }
+    __hot inline slice pure_slice::find(pure_slice target) const noexcept {
+        char* src    = (char*)buf;
+        char* search = (char*)target.buf;
+        char* found  = std::search(src, src + size, search, search + target.size);
+        if ( found == src + size ) { return nullslice; }
 
         return {found, target.size};
     }
 
+    inline bool pure_slice::containsBytes(pure_slice bytes) const noexcept { return bool(find(bytes)); }
 
-    inline bool pure_slice::containsBytes(pure_slice bytes) const noexcept {
-        return bool(find(bytes));
-    }
-
-
-    __hot
-    inline const uint8_t* FL_NULLABLE pure_slice::findByte(uint8_t b) const {
-        if (_usuallyFalse(size == 0))
-            return nullptr;
+    __hot inline const uint8_t* FL_NULLABLE pure_slice::findByte(uint8_t b) const {
+        if ( _usuallyFalse(size == 0) ) return nullptr;
         return (const uint8_t*)::memchr(buf, b, size);
     }
 
-
-    __hot
-    inline const uint8_t* FL_NULLABLE pure_slice::findByteOrEnd(uint8_t byte) const noexcept {
+    __hot inline const uint8_t* FL_NULLABLE pure_slice::findByteOrEnd(uint8_t byte) const noexcept {
         auto result = findByte(byte);
         return result ? result : (const uint8_t*)end();
     }
 
-
-    __hot
-    inline const uint8_t* FL_NULLABLE pure_slice::findAnyByteOf(pure_slice targetBytes) const noexcept {
+    __hot inline const uint8_t* FL_NULLABLE pure_slice::findAnyByteOf(pure_slice targetBytes) const noexcept {
         // this could totally be optimized, if it turns out to matter...
         const void* result = nullptr;
-        for (size_t i = 0; i < targetBytes.size; ++i) {
+        for ( size_t i = 0; i < targetBytes.size; ++i ) {
             auto r = findByte(targetBytes[i]);
-            if (r && (!result || r < result))
-                result = r;
+            if ( r && (!result || r < result) ) result = r;
         }
         return (const uint8_t*)result;
     }
 
-
-    __hot
-    inline const uint8_t* FL_NULLABLE pure_slice::findByteNotIn(pure_slice targetBytes) const noexcept {
-        for (auto c = (const uint8_t*)buf; c != end(); ++c) {
-            if (!targetBytes.findByte(*c))
-                return c;
+    __hot inline const uint8_t* FL_NULLABLE pure_slice::findByteNotIn(pure_slice targetBytes) const noexcept {
+        for ( auto c = (const uint8_t*)buf; c != end(); ++c ) {
+            if ( !targetBytes.findByte(*c) ) return c;
         }
         return nullptr;
     }
-
 
     inline bool pure_slice::hasPrefix(pure_slice s) const noexcept {
         return s.size > 0 && size >= s.size && ::memcmp(buf, s.buf, s.size) == 0;
     }
 
-
     inline bool pure_slice::hasSuffix(pure_slice s) const noexcept {
-        return s.size > 0 && size >= s.size
-            && ::memcmp(offsetby(buf, size - s.size), s.buf, s.size) == 0;
+        return s.size > 0 && size >= s.size && ::memcmp(offsetby(buf, size - s.size), s.buf, s.size) == 0;
     }
 
-
-#pragma mark  MEMORY ALLOCATION
-
+#    pragma mark MEMORY ALLOCATION
 
     /** Raw memory allocation. Just like malloc but throws/terminates on failure. */
     RETURNS_NONNULL
     inline void* pure_slice::newBytes(size_t sz) {
         void* result = ::malloc(sz);
-        if (_usuallyFalse(!result)) failBadAlloc();
+        if ( _usuallyFalse(!result) ) failBadAlloc();
         return result;
     }
 
-
     /** Like realloc but throws/terminates on failure. */
     template <typename T>
-    RETURNS_NONNULL
-    inline T* FL_NONNULL pure_slice::reallocBytes(T* FL_NULLABLE bytes, size_t newSz) {
+    RETURNS_NONNULL inline T* FL_NONNULL pure_slice::reallocBytes(T* FL_NULLABLE bytes, size_t newSz) {
         T* newBytes = (T*)::realloc(bytes, newSz);
-        if (_usuallyFalse(!newBytes)) failBadAlloc();
+        if ( _usuallyFalse(!newBytes) ) failBadAlloc();
         return newBytes;
     }
 
     inline slice pure_slice::copy() const {
-        if (buf == nullptr)
-            return nullslice;
+        if ( buf == nullptr ) return nullslice;
         void* copied = newBytes(size);
         FLMemCpy(copied, buf, size);
         return slice(copied, size);
     }
 
-
-    [[noreturn]]
-    inline void pure_slice::failBadAlloc() {
-#ifdef __cpp_exceptions
+    [[noreturn]] inline void pure_slice::failBadAlloc() {
+#    ifdef __cpp_exceptions
         throw std::bad_alloc();
-#else
+#    else
         ::fputs("*** FATAL ERROR: heap allocation failed (fleece/slice.cc) ***\n", stderr);
         std::terminate();
-#endif
+#    endif
     }
 
+#    pragma mark - SLICE METHOD BODIES:
 
-#pragma mark - SLICE METHOD BODIES:
+    inline constexpr slice::slice(nullslice_t) noexcept : pure_slice() {}
 
+    inline constexpr slice::slice(const alloc_slice& s) noexcept : pure_slice(s) {}
 
-    inline constexpr slice::slice(nullslice_t) noexcept           :pure_slice() {}
-    inline constexpr slice::slice(const alloc_slice &s) noexcept  :pure_slice(s) { }
-
-
-    inline constexpr slice::slice(const void* start, const void* end) noexcept
-    :slice(start, pointerDiff(end, start))
-    {
+    inline constexpr slice::slice(const void* start, const void* end) noexcept : slice(start, pointerDiff(end, start)) {
         assert_precondition(end >= start);
     }
 
-
-    inline slice& slice::operator= (nullslice_t) noexcept {
+    inline slice& slice::operator=(nullslice_t) noexcept {
         set(nullptr, 0);
         return *this;
     }
 
+    inline slice::operator FLSliceResult() const noexcept { return FLSliceResult(alloc_slice(*this)); }
 
-    inline slice::operator FLSliceResult () const noexcept {
-        return FLSliceResult(alloc_slice(*this));
-    }
+    inline void slice::shorten(size_t s) { setSize(check(s)); }
 
-
-    inline void slice::shorten(size_t s) {
-        setSize(check(s));
-    }
-
-
-    inline void slice::setStart(const void *s) noexcept {
+    inline void slice::setStart(const void* s) noexcept {
         check(s);
         set(s, pointerDiff(end(), s));
     }
 
+#    pragma mark - ALLOC_SLICE METHOD BODIES:
 
-#pragma mark - ALLOC_SLICE METHOD BODIES:
-
-
-    __hot
-    inline alloc_slice::alloc_slice(size_t sz)
-    :alloc_slice(FLSliceResult_New(sz))
-    {
-        if (_usuallyFalse(!buf))
-            failBadAlloc();
+    __hot inline alloc_slice::alloc_slice(size_t sz) : alloc_slice(FLSliceResult_New(sz)) {
+        if ( _usuallyFalse(!buf) ) failBadAlloc();
     }
 
-
-    __hot
-    inline alloc_slice::alloc_slice(pure_slice s)
-    :alloc_slice(FLSlice_Copy(s))
-    {
-        if (_usuallyFalse(!buf) && s.buf)
-            failBadAlloc();
+    __hot inline alloc_slice::alloc_slice(pure_slice s) : alloc_slice(FLSlice_Copy(s)) {
+        if ( _usuallyFalse(!buf) && s.buf ) failBadAlloc();
     }
-
 
     inline alloc_slice alloc_slice::nullPaddedString(pure_slice str) {
         // Leave a trailing null byte after the end, so it can be used as a C string
         alloc_slice a(str.size + 1);
         str.copyTo((void*)a.buf);
         ((char*)a.buf)[str.size] = '\0';
-        a.shorten(str.size);            // the null byte is not part of the slice
+        a.shorten(str.size);  // the null byte is not part of the slice
         return a;
     }
 
-
-    __hot
-    inline alloc_slice& alloc_slice::operator=(const alloc_slice& s) noexcept {
-        if (_usuallyTrue(s.buf != buf)) {
+    __hot inline alloc_slice& alloc_slice::operator=(const alloc_slice& s) noexcept {
+        if ( _usuallyTrue(s.buf != buf) ) {
             release();
             assignFrom(s);
             retain();
@@ -833,10 +837,8 @@ namespace fleece {
         return *this;
     }
 
-
-    __hot
-    inline alloc_slice& alloc_slice::operator=(FLHeapSlice s) noexcept {
-        if (_usuallyTrue(s.buf != buf)) {
+    __hot inline alloc_slice& alloc_slice::operator=(FLHeapSlice s) noexcept {
+        if ( _usuallyTrue(s.buf != buf) ) {
             release();
             assignFrom(slice(s));
             retain();
@@ -844,11 +846,10 @@ namespace fleece {
         return *this;
     }
 
-
     inline void alloc_slice::resize(size_t newSize) {
-        if (newSize == size) {
+        if ( newSize == size ) {
             return;
-        } else if (buf == nullptr) {
+        } else if ( buf == nullptr ) {
             reset(newSize);
         } else {
             // We don't realloc the current buffer; that would affect other alloc_slice objects
@@ -859,13 +860,11 @@ namespace fleece {
         }
     }
 
-
     inline void alloc_slice::append(pure_slice source) {
-        if (_usuallyFalse(source.size == 0))
-            return;
-        const void *src = source.buf;
-        size_t oldSize = size;
-        if (_usuallyFalse(containsAddress(src))) {
+        if ( _usuallyFalse(source.size == 0) ) return;
+        const void* src     = source.buf;
+        size_t      oldSize = size;
+        if ( _usuallyFalse(containsAddress(src)) ) {
             // Edge case, where I contain the source bytes: update source address after realloc
             size_t srcOff = size_t(pointerDiff(src, buf));
             resize(oldSize + source.size);
@@ -876,26 +875,24 @@ namespace fleece {
         ::memcpy((void*)offset(oldSize), src, source.size);  // already checked source.size > 0
     }
 
+    inline void alloc_slice::shorten(size_t s) { pure_slice::setSize(check(s)); }
 
-    inline void alloc_slice::shorten(size_t s) {
-        pure_slice::setSize(check(s));
-    }
-
-}
-
+}  // namespace fleece
 
 namespace std {
     // Declare the default hash function for `slice` and `alloc_slice`. This allows them to be
     // used in hashed collections like `std::unordered_map` and `std::unordered_set`.
-    template<> struct hash<fleece::slice> {
-        std::size_t operator() (fleece::pure_slice const& s) const {return s.hash();}
+    template <>
+    struct hash<fleece::slice> {
+        std::size_t operator()(fleece::pure_slice const& s) const { return s.hash(); }
     };
-    template<> struct hash<fleece::alloc_slice> {
-        std::size_t operator() (fleece::pure_slice const& s) const {return s.hash();}
-    };
-}
 
+    template <>
+    struct hash<fleece::alloc_slice> {
+        std::size_t operator()(fleece::pure_slice const& s) const { return s.hash(); }
+    };
+}  // namespace std
 
 FL_ASSUME_NONNULL_END
 
-#endif // _FLEECE_SLICE_HH
+#endif  // _FLEECE_SLICE_HH

--- a/Fleece/Core/Dict.hh
+++ b/Fleece/Core/Dict.hh
@@ -23,7 +23,7 @@ namespace fleece { namespace impl {
 
     /** A Value that's a dictionary/map */
     class Dict : public Value {
-    public:
+      public:
         /** The number of items in the dictionary. */
         uint32_t count() const noexcept FLPURE;
 
@@ -40,13 +40,13 @@ namespace fleece { namespace impl {
 
 #ifdef __OBJC__
         /** Looks up the Value for a key given as an NSString object. */
-        const Value* get(NSString* key NONNULL) const noexcept {
+        const Value* get(NSString* FL_NONNULL key) const noexcept {
             nsstring_slice keyBytes(key);
             return get(keyBytes);
         }
 #endif
 
-        bool isEqualToDict(const Dict* NONNULL) const noexcept FLPURE;
+        bool isEqualToDict(const Dict* FL_NONNULL) const noexcept FLPURE;
 
         /** An empty Dict. */
         static const Dict* const kEmpty;
@@ -61,26 +61,33 @@ namespace fleece { namespace impl {
             Warning: An instance of this should be used only on a single thread, and only with
             documents that share the same SharedKeys. */
         class key {
-        public:
+          public:
             /** Constructs a key from a string.
                 Warning: the input string's memory MUST remain valid for as long as the key is in
                 use! (The key stores a pointer to the string, but does not copy it.) */
-            key(slice rawString)                         :_rawString(rawString) { }
-            ~key();
-            slice string() const noexcept                {return _rawString;}
-            int compare(const key &k) const noexcept     {return _rawString.compare(k._rawString);}
-            key(const key&) =delete;
-            bool isShared() const noexcept               {return _hasNumericKey;}
-        private:
-            void setSharedKeys(SharedKeys*);
-            
-            slice const _rawString;
-            SharedKeys* _sharedKeys {nullptr};
-            uint32_t _hint          {0xFFFFFFFF};
-            int32_t _numericKey;
-            bool _hasNumericKey     {false};
+            key(slice rawString) : _rawString(rawString) {}
 
-            template <bool WIDE> friend struct dictImpl;
+            ~key();
+
+            slice string() const noexcept { return _rawString; }
+
+            int compare(const key& k) const noexcept { return _rawString.compare(k._rawString); }
+
+            key(const key&) = delete;
+
+            bool isShared() const noexcept { return _hasNumericKey; }
+
+          private:
+            void setSharedKeys(SharedKeys*);
+
+            slice const _rawString;
+            SharedKeys* _sharedKeys{nullptr};
+            uint32_t    _hint{0xFFFFFFFF};
+            int32_t     _numericKey;
+            bool        _hasNumericKey{false};
+
+            template <bool WIDE>
+            friend struct dictImpl;
         };
 
         /** Looks up the Value for a key, in a form that can cache the key's Fleece object.
@@ -89,30 +96,30 @@ namespace fleece { namespace impl {
 
         const Value* get(const key_t&) const noexcept;
 
-        constexpr Dict()  :Value(internal::kDictTag, 0, 0) { }
+        constexpr Dict() : Value(internal::kDictTag, 0, 0) {}
 
-    protected:
+      protected:
         internal::HeapDict* heapDict() const noexcept FLPURE;
-        uint32_t rawCount() const noexcept FLPURE;
-        const Dict* getParent() const noexcept FLPURE;
+        uint32_t            rawCount() const noexcept FLPURE;
+        const Dict*         getParent() const noexcept FLPURE;
 
         // This is like `get` but returns the key _as stored in the Dict_, either slice or int.
-        key_t encodeKey(slice keyString, SharedKeys *sharedKeys NONNULL) const noexcept;
+        key_t encodeKey(slice keyString, SharedKeys* FL_NONNULL sharedKeys) const noexcept;
 
-        static bool isMagicParentKey(const Value *v);
+        static bool          isMagicParentKey(const Value* v);
         static constexpr int kMagicParentKey = -2048;
 
-        template <bool WIDE> friend struct dictImpl;
+        template <bool WIDE>
+        friend struct dictImpl;
         friend class DictIterator;
         friend class Value;
         friend class Encoder;
         friend class internal::HeapDict;
     };
 
-
     /** A stack-based dictionary iterator */
     class DictIterator {
-    public:
+      public:
         /** Constructs an iterator. It's OK for the Dict to be null. */
         DictIterator(const Dict*) noexcept;
 
@@ -120,47 +127,52 @@ namespace fleece { namespace impl {
         DictIterator(const Dict*, const SharedKeys*) noexcept;
 
         /** Returns the number of _remaining_ items. */
-        uint32_t count() const noexcept FLPURE                  {return _a._count;}
+        uint32_t count() const noexcept FLPURE { return _a._count; }
 
         slice keyString() const noexcept;
-        const Value* key() const noexcept FLPURE                {return _key;}
-        const Value* value() const noexcept FLPURE              {return _value;}
+
+        const Value* key() const noexcept FLPURE { return _key; }
+
+        const Value* value() const noexcept FLPURE { return _value; }
 
         /** Returns false when the iterator reaches the end. */
-        explicit operator bool() const noexcept FLPURE          {return _key != nullptr;}
+        explicit operator bool() const noexcept FLPURE { return _key != nullptr; }
 
         /** Steps to the next item. (Throws if there are no more items.) */
-        DictIterator& operator ++();
+        DictIterator& operator++();
 
         /** Steps forward by one or more items. (Throws if stepping past the end.) */
-        DictIterator& operator += (uint32_t);
+        DictIterator& operator+=(uint32_t);
 
-        const SharedKeys* sharedKeys() const FLPURE            {return _sharedKeys;}
+        const SharedKeys* sharedKeys() const FLPURE { return _sharedKeys; }
+
         key_t keyt() const noexcept;
 
 #ifdef __OBJC__
-        NSString* keyToNSString(NSMapTable *sharedStrings) const;
+        NSString* keyToNSString(NSMapTable* sharedStrings) const;
 #endif
 
-    private:
-        DictIterator(const Dict* d, bool) noexcept;     // for Value::dump() only
+      private:
+             DictIterator(const Dict* d, bool) noexcept;  // for Value::dump() only
         void readKV() noexcept;
-        const Value* rawKey() noexcept             {return _a._first;}
-        const Value* rawValue() noexcept           {return _a.second();}
+
+        const Value* rawKey() noexcept { return _a._first; }
+
+        const Value* rawValue() noexcept { return _a.second(); }
+
         SharedKeys* findSharedKeys() const;
 
-        Array::impl _a;
-        const Value *_key, *_value;
-        mutable const SharedKeys *_sharedKeys {nullptr};
+        Array::impl                   _a;
+        const Value *                 _key, *_value;
+        mutable const SharedKeys*     _sharedKeys{nullptr};
         std::unique_ptr<DictIterator> _parent;
-        int _keyCmp {-1};
+        int                           _keyCmp{-1};
 
         friend class Value;
         friend class ValueDumper;
         friend class Encoder;
     };
 
+    inline Dict::iterator Dict::begin() const noexcept { return iterator(this); }
 
-    inline Dict::iterator Dict::begin() const noexcept    {return iterator(this);}
-
-} }
+}}  // namespace fleece::impl

--- a/Fleece/Core/Doc.hh
+++ b/Fleece/Core/Doc.hh
@@ -20,103 +20,90 @@
 namespace fleece { namespace impl {
     class SharedKeys;
     class Value;
+
     namespace internal {
         class Pointer;
     }
 
-
     class Scope {
-    public:
-        Scope(slice fleeceData,
-              SharedKeys*,
-              slice externDestination =nullslice,
-              bool isDoc =false) noexcept;
-        Scope(const alloc_slice &fleeceData,
-              SharedKeys*,
-              slice externDestination =nullslice,
-              bool isDoc =false) noexcept;
-        Scope(const Scope &parentScope,
-              slice subData,
-              bool isDoc =false) noexcept;
+      public:
+        Scope(slice fleeceData, SharedKeys*, slice externDestination = nullslice, bool isDoc = false) noexcept;
+        Scope(const alloc_slice& fleeceData, SharedKeys*, slice externDestination = nullslice,
+              bool isDoc = false) noexcept;
+        Scope(const Scope& parentScope, slice subData, bool isDoc = false) noexcept;
 
         // Scope doesn't need a vtable, but it's useful for identifying subclasses, for example:
         //     auto s = dynamic_cast<const MyScope*>(Scope::containing(val));
         // The dynamic_cast will safely check whether the returned Scope is a MyScope instance.
         virtual ~Scope();
 
-        static const Scope* containing(const Value* NONNULL) noexcept;
+        static const Scope* containing(const Value* FL_NONNULL) noexcept;
 
-        slice data() const FLPURE                      {return _data;}
-        alloc_slice allocedData() const FLPURE         {return _alloced;}
+        slice data() const FLPURE { return _data; }
 
-        SharedKeys* sharedKeys() const FLPURE          {return _sk;}
-        slice externDestination() const FLPURE         {return _externDestination;}
+        alloc_slice allocedData() const FLPURE { return _alloced; }
+
+        SharedKeys* sharedKeys() const FLPURE { return _sk; }
+
+        slice externDestination() const FLPURE { return _externDestination; }
 
         // For internal use:
 
-        static SharedKeys* sharedKeys(const Value* NONNULL v) noexcept;
-        const Value* resolveExternPointerTo(const void* NONNULL) const noexcept;
-        static const Value* resolvePointerFrom(const internal::Pointer* NONNULL src,
-                                               const void* NONNULL dst) noexcept;
-        static std::pair<const Value*,slice> resolvePointerFromWithRange(
-                                                                         const internal::Pointer* NONNULL src,
-                                                                         const void* NONNULL dst) noexcept;
-        static void dumpAll();
+        static SharedKeys*                    sharedKeys(const Value* FL_NONNULL v) noexcept;
+        const Value*                          resolveExternPointerTo(const void* FL_NONNULL) const noexcept;
+        static const Value*                   resolvePointerFrom(const internal::Pointer* FL_NONNULL src,
+                                                                 const void* FL_NONNULL              dst) noexcept;
+        static std::pair<const Value*, slice> resolvePointerFromWithRange(const internal::Pointer* FL_NONNULL src,
+                                                                          const void* FL_NONNULL dst) noexcept;
+        static void                           dumpAll();
 
-    protected:
-        static const Scope* _containing(const Value* NONNULL) noexcept;
-        void unregister() noexcept;
+      protected:
+        static const Scope* _containing(const Value* FL_NONNULL) noexcept;
+        void                unregister() noexcept;
 
-    private:
-        Scope(const Scope&) =delete;
+      private:
+             Scope(const Scope&) = delete;
         void registr() noexcept;
 
-        Retained<SharedKeys> _sk;                       // SharedKeys used for this Fleece data
-        slice const         _externDestination;         // Extern ptr destination for this data
-        slice const         _data;                      // The memory range I represent
-        alloc_slice const   _alloced;                   // Retains data if it's an alloc_slice
-        std::atomic_flag    _unregistered ATOMIC_FLAG_INIT; // False if registered in sMemoryMap
+        Retained<SharedKeys>           _sk;                 // SharedKeys used for this Fleece data
+        slice const                    _externDestination;  // Extern ptr destination for this data
+        slice const                    _data;               // The memory range I represent
+        alloc_slice const              _alloced;            // Retains data if it's an alloc_slice
+        std::atomic_flag _unregistered ATOMIC_FLAG_INIT;    // False if registered in sMemoryMap
 #if DEBUG
-        uint32_t            _dataHash;                  // hash of _data, for troubleshooting
+        uint32_t _dataHash;  // hash of _data, for troubleshooting
 #endif
-    protected:
-        bool                _isDoc {false};             // True if I am a field of a Doc
+      protected:
+        bool _isDoc{false};  // True if I am a field of a Doc
         friend class Doc;
     };
-
 
     /** A container for Fleece data in memory. Every Value belongs to the Doc whose memory range
         contains it. The Doc keeps track of the SharedKeys used by its Dicts, and where to resolve
         external pointers to. */
-    class Doc : public RefCounted, public Scope {
-    public:
-        enum Trust {
-            kUntrusted, kTrusted,
-            kDontParse = -1
-        };
+    class Doc
+        : public RefCounted
+        , public Scope {
+      public:
+        enum Trust { kUntrusted, kTrusted, kDontParse = -1 };
 
-        explicit
-        Doc(const alloc_slice &fleeceData,
-            Trust =kUntrusted,
-            SharedKeys* =nullptr,
-            slice externDest =nullslice) noexcept;
+        explicit Doc(const alloc_slice& fleeceData, Trust = kUntrusted, SharedKeys* = nullptr,
+                     slice              externDest = nullslice) noexcept;
 
-        Doc(const Doc *parentDoc NONNULL,
-            slice subData,
-            Trust =kUntrusted) noexcept;
+        Doc(const Doc* FL_NONNULL parentDoc, slice subData, Trust = kUntrusted) noexcept;
 
-        Doc(const Scope &parentScope,
-            slice subData,
-            Trust =kUntrusted) noexcept;
+        Doc(const Scope& parentScope, slice subData, Trust = kUntrusted) noexcept;
 
-        static Retained<Doc> fromFleece(const alloc_slice &fleece, Trust =kUntrusted);
-        static Retained<Doc> fromJSON(slice json, SharedKeys* =nullptr);
+        static Retained<Doc> fromFleece(const alloc_slice& fleece, Trust = kUntrusted);
+        static Retained<Doc> fromJSON(slice json, SharedKeys* = nullptr);
 
-        static RetainedConst<Doc> containing(const Value* NONNULL) noexcept;
+        static RetainedConst<Doc> containing(const Value* FL_NONNULL) noexcept;
 
-        const Value* root() const FLPURE               {return _root;}
-        const Dict* asDict() const FLPURE              {return _root ? _root->asDict() : nullptr;}
-        const Array* asArray() const FLPURE            {return _root ? _root->asArray() : nullptr;}
+        const Value* root() const FLPURE { return _root; }
+
+        const Dict* asDict() const FLPURE { return _root ? _root->asDict() : nullptr; }
+
+        const Array* asArray() const FLPURE { return _root ? _root->asArray() : nullptr; }
 
         /// Allows client code to associate its own pointer with this Doc and its Values,
         /// which can later be retrieved with \ref getAssociated.
@@ -130,7 +117,7 @@ namespace fleece { namespace impl {
         ///          already stored.
         /// @warning  Be sure to clear this before the associated object is freed/invalidated!
         /// @warning  This method is not thread-safe. Do not concurrently get & set objects.
-        bool setAssociated(void *pointer, const char *type);
+        bool setAssociated(void* pointer, const char* type);
 
         /// Returns a pointer previously stored in this Doc by \ref setAssociated.
         /// For example, you would look up an `app::Document` object by calliing
@@ -138,24 +125,23 @@ namespace fleece { namespace impl {
         /// @param type  The type of object expected, i.e. the same string literal passed to the
         ///              \ref setAssociatedObject method.
         /// @return  The associated pointer of that type, if any.
-        void* getAssociated(const char *type) const;
+        void* getAssociated(const char* type) const;
 
-    protected:
-        virtual ~Doc() =default;
+      protected:
+        virtual ~Doc() = default;
 
-    private:
+      private:
         void init(Trust) noexcept;
 
-        const Value*        _root {nullptr};            // The root object of the Fleece
-        RetainedConst<Doc>  _parent;
-        void*               _associatedPointer {nullptr};
-        const char*         _associatedType {nullptr};
+        const Value*       _root{nullptr};  // The root object of the Fleece
+        RetainedConst<Doc> _parent;
+        void*              _associatedPointer{nullptr};
+        const char*        _associatedType{nullptr};
     };
 
-} }
-
+}}  // namespace fleece::impl
 
 extern "C" {
-    // For debugging only; to be called from a debugger
-    void FLDumpScopes();
+// For debugging only; to be called from a debugger
+void FLDumpScopes();
 }

--- a/Fleece/Core/Encoder.cc
+++ b/Fleece/Core/Encoder.cc
@@ -539,7 +539,7 @@ namespace fleece { namespace impl {
     }
 
 
-    void Encoder::writeValue(const Value* NONNULL value, const WriteValueFunc *fn) {
+    void Encoder::writeValue(const Value* FL_NONNULL value, const WriteValueFunc *fn) {
         const SharedKeys *sk = nullptr;
         writeValue(value, sk, fn);
     }

--- a/Fleece/Core/Encoder.hh
+++ b/Fleece/Core/Encoder.hh
@@ -19,23 +19,21 @@
 #include "SmallVector.hh"
 #include "fleece/function_ref.hh"
 
-
 namespace fleece { namespace impl {
     class SharedKeys;
     class key_t;
 
-
     /** Generates Fleece-encoded data. */
     class Encoder {
-    public:
+      public:
         /** Constructs an encoder. */
-        Encoder(size_t reserveOutputSize =256);
-        Encoder(FILE* NONNULL);
+         Encoder(size_t reserveOutputSize = 256);
+         Encoder(FILE* FL_NONNULL);
         ~Encoder();
 
         /** Sets the uniqueStrings property. If true (the default), the encoder tries to write
             each unique string only once. This saves space but makes the encoder slightly slower. */
-        void uniqueStrings(bool b)      {_uniqueStrings = b;}
+        void uniqueStrings(bool b) { _uniqueStrings = b; }
 
         /** Sets the base Fleece data that the encoded data will be (logically) appended to.
             Any writeValue() calls whose Value points into the base data will be written as
@@ -48,17 +46,18 @@ namespace fleece { namespace impl {
             @param cutoff  If nonzero, this specifies the maximum number of bytes of the base
                         (starting from the end) that should be used. Any base data before
                         the cutoff will not be referenced in the encoder output. */
-        void setBase(slice base, bool markExternPointers =false, size_t cutoff =0);
+        void setBase(slice base, bool markExternPointers = false, size_t cutoff = 0);
 
         /** Scans the base document for strings and adds them to the encoder's string table.
             If equivalent strings are written to the encoder they will then be encoded as pointers
             to the existing strings. */
         void reuseBaseStrings();
 
-        bool valueIsInBase(const Value *value) const;
+        bool valueIsInBase(const Value* value) const;
 
-        bool isEmpty() const            {return _out.length() == 0 && _stackDepth == 1 && _items->empty();}
-        size_t bytesWritten() const     {return _out.length();} // may be an underestimate
+        bool isEmpty() const { return _out.length() == 0 && _stackDepth == 1 && _items->empty(); }
+
+        size_t bytesWritten() const { return _out.length(); }  // may be an underestimate
 
         /** Ends encoding, writing the last of the data to the Writer. */
         void end();
@@ -83,20 +82,20 @@ namespace fleece { namespace impl {
         void writeFloat(float);
         void writeDouble(double);
 
-        void writeString(slice s)                           {(void)_writeString(s);}
+        void writeString(slice s) { (void)_writeString(s); }
 
-        void writeDateString(int64_t timestamp, bool asUTC =true);
+        void writeDateString(int64_t timestamp, bool asUTC = true);
 
         void writeData(slice s);
 
-        void writeValue(const Value* NONNULL v)             {writeValue(v, nullptr);}
+        void writeValue(const Value* FL_NONNULL v) { writeValue(v, nullptr); }
 
-        using WriteValueFunc = function_ref<bool(const Value *key, const Value *value)>;
+        using WriteValueFunc = function_ref<bool(const Value* key, const Value* value)>;
 
         /** Alternative writeValue that invokes a callback before writing any Value.
             If the callback returns false, the value is written as usual, otherwise it's skipped;
             the callback can invoke the Encoder to write a different Value instead if it likes. */
-        void writeValue(const Value* NONNULL v, WriteValueFunc fn)  {writeValue(v, &fn);}
+        void writeValue(const Value* FL_NONNULL v, WriteValueFunc fn) { writeValue(v, &fn); }
 
 #ifdef __OBJC__
         /** Writes an Objective-C object. Supported classes are the ones allowed by
@@ -110,7 +109,7 @@ namespace fleece { namespace impl {
             added to this array.
             @param reserve  If nonzero, space is preallocated for this many values. This has no
                             effect on the output but can speed up encoding slightly. */
-        void beginArray(size_t reserve =0);
+        void beginArray(size_t reserve = 0);
 
         /** Ends creating an array. The array is written to the output and added as a Value to
             the next outermost collection (or made the root if there is no collection active.) */
@@ -123,10 +122,10 @@ namespace fleece { namespace impl {
             While creating a dictionary, writeKey must be called before every value.
             @param reserve  If nonzero, space is preallocated for this many values. This has no
                             effect on the output but can speed up encoding slightly. */
-        void beginDictionary(size_t reserve =0);
+        void beginDictionary(size_t reserve = 0);
 
         /** Begins creating a dictionary which inherits from an existing dictionary. */
-        void beginDictionary(const Dict *parent NONNULL, size_t reserve =0);
+        void beginDictionary(const Dict* FL_NONNULL parent, size_t reserve = 0);
 
         /** Ends creating a dictionary. The dict is written to the output and added as a value to
             the next outermost collection (or made the root if there is no collection active.) */
@@ -136,45 +135,93 @@ namespace fleece { namespace impl {
         void writeKey(slice);
 
         /** Writes a string or int Value as a key to the current dictionary. */
-        void writeKey(const Value* NONNULL, const SharedKeys* =nullptr);
+        void writeKey(const Value* FL_NONNULL, const SharedKeys* = nullptr);
 
         void writeKey(key_t);
 
         /** Associates a SharedKeys object with this Encoder. The writeKey() methods that take
             strings will consult this object to possibly map the key to an integer. */
-        void setSharedKeys(SharedKeys *s);
+        void setSharedKeys(SharedKeys* s);
 
         //////// "<<" convenience operators;
 
         // Note: overriding <<(bool) would be dangerous due to implicit conversion
-        Encoder& operator<< (Null)              {writeNull(); return *this;}
-        Encoder& operator<< (long long i)       {writeInt(i); return *this;}
-        Encoder& operator<< (unsigned long long i)  {writeUInt(i); return *this;}
-        Encoder& operator<< (long i)            {writeInt(i); return *this;}
-        Encoder& operator<< (unsigned long i)   {writeUInt(i); return *this;}
-        Encoder& operator<< (int i)             {writeInt(i); return *this;}
-        Encoder& operator<< (unsigned int i)    {writeUInt(i); return *this;}
-        Encoder& operator<< (double d)          {writeDouble(d); return *this;}
-        Encoder& operator<< (float f)           {writeFloat(f); return *this;}
-        Encoder& operator<< (slice s)           {writeString(s); return *this;} // string not data!
-        Encoder& operator<< (const Value *v NONNULL)    {writeValue(v); return *this;}
+        Encoder& operator<<(Null) {
+            writeNull();
+            return *this;
+        }
+
+        Encoder& operator<<(long long i) {
+            writeInt(i);
+            return *this;
+        }
+
+        Encoder& operator<<(unsigned long long i) {
+            writeUInt(i);
+            return *this;
+        }
+
+        Encoder& operator<<(long i) {
+            writeInt(i);
+            return *this;
+        }
+
+        Encoder& operator<<(unsigned long i) {
+            writeUInt(i);
+            return *this;
+        }
+
+        Encoder& operator<<(int i) {
+            writeInt(i);
+            return *this;
+        }
+
+        Encoder& operator<<(unsigned int i) {
+            writeUInt(i);
+            return *this;
+        }
+
+        Encoder& operator<<(double d) {
+            writeDouble(d);
+            return *this;
+        }
+
+        Encoder& operator<<(float f) {
+            writeFloat(f);
+            return *this;
+        }
+
+        Encoder& operator<<(slice s) {
+            writeString(s);
+            return *this;
+        }  // string not data!
+
+        Encoder& operator<<(const Value* FL_NONNULL v) {
+            writeValue(v);
+            return *this;
+        }
 
         //////// Pre-encoded scalar values for convenience:
 
         static const slice kPreEncodedTrue, kPreEncodedFalse, kPreEncodedNull, kPreEncodedEmptyDict;
 
         // For advanced use cases only... be careful!
-        void suppressTrailer()                  {_trailer = false;}
-        void writeRaw(slice s)                  {_out.write(s);}
+        void suppressTrailer() { _trailer = false; }
+
+        void writeRaw(slice s) { _out.write(s); }
+
         size_t nextWritePos();
         size_t finishItem();
-        slice base() const                      {return _base;}
-        slice baseUsed() const                  {return _baseMinUsed != 0 ? slice(_baseMinUsed, _base.end()) : slice();}
-        const StringTable& strings() const      {return _strings;}
+
+        slice base() const { return _base; }
+
+        slice baseUsed() const { return _baseMinUsed != 0 ? slice(_baseMinUsed, _base.end()) : slice(); }
+
+        const StringTable& strings() const { return _strings; }
 
         enum class PreWrittenValue : intptr_t { none = INTPTR_MIN };
-        PreWrittenValue lastValueWritten() const;   // Opaque reference to last thing written
-        bool writeValueAgain(PreWrittenValue);      // Writes pointer to an already-written value
+        PreWrittenValue lastValueWritten() const;          // Opaque reference to last thing written
+        bool            writeValueAgain(PreWrittenValue);  // Writes pointer to an already-written value
 
         /** Returns the data written so far as a standalone Fleece document, whose root is the last
             value written. You can continue writing, and the final output returned by \ref finish will
@@ -188,82 +235,90 @@ namespace fleece { namespace impl {
 #endif
         static bool isFloatRepresentable(double n) noexcept;
 
-    private:
+      private:
         using byte = uint8_t;
 
-        static constexpr size_t kInitialStackSize = 4;
+        static constexpr size_t kInitialStackSize          = 4;
         static constexpr size_t kInitialCollectionCapacity = 16;
 
         // Stores the pending values to be written to an in-progress array/dict
         class valueArray : public smallVector<Value, kInitialCollectionCapacity> {
-        public:
-            valueArray()                    =default;
-            void reset(internal::tags t)    {tag = t; wide = false; keys.clear();}
-            
-            internal::tags tag;
-            bool wide;
+          public:
+            valueArray() = default;
+
+            void reset(internal::tags t) {
+                tag  = t;
+                wide = false;
+                keys.clear();
+            }
+
+            internal::tags                                   tag;
+            bool                                             wide;
             smallVector<FLSlice, kInitialCollectionCapacity> keys;
         };
 
-        void init();
-        void resetStack();
+        void  init();
+        void  resetStack();
         byte* placeItem();
-        void addSpecial(int specialValue);
-        template <bool canInline> byte* placeValue(size_t size);
-        template <bool canInline> byte* placeValue(internal::tags tag, byte param, size_t size);
-        void reuseBaseStrings(const Value* NONNULL);
-        void cacheString(slice s, size_t offsetInBase);
-        static bool isNarrowValue(const Value *value NONNULL);
-        void writePointer(ssize_t pos);
-        void writeSpecial(uint8_t special);
-        void writeInt(uint64_t i, bool isShort, bool isUnsigned);
-        template<typename Float, typename Swapped> void _writeFloat(Float, byte param);
-        const void* writeData(internal::tags, slice s);
-        const void* _writeString(slice);
-        void addingKey();
-        void addedKey(FLSlice str);
-        void sortDict(valueArray &items);
-        void checkPointerWidths(valueArray *items NONNULL, size_t writePos);
-        void fixPointers(valueArray *items NONNULL);
-        void endCollection(internal::tags tag);
-        void push(internal::tags tag, size_t reserve);
-        inline void pop();
-        void writeKey(int);
-        void writeValue(const Value* NONNULL, const WriteValueFunc*);
-        void writeValue(const Value* NONNULL, const SharedKeys* &, const WriteValueFunc*);
-        const Value* minUsed(const Value *value);
+        void  addSpecial(int specialValue);
+        template <bool canInline>
+        byte* placeValue(size_t size);
+        template <bool canInline>
+        byte*       placeValue(internal::tags tag, byte param, size_t size);
+        void        reuseBaseStrings(const Value* FL_NONNULL);
+        void        cacheString(slice s, size_t offsetInBase);
+        static bool isNarrowValue(const Value* FL_NONNULL value);
+        void        writePointer(ssize_t pos);
+        void        writeSpecial(uint8_t special);
+        void        writeInt(uint64_t i, bool isShort, bool isUnsigned);
+        template <typename Float, typename Swapped>
+        void         _writeFloat(Float, byte param);
+        const void*  writeData(internal::tags, slice s);
+        const void*  _writeString(slice);
+        void         addingKey();
+        void         addedKey(FLSlice str);
+        void         sortDict(valueArray& items);
+        void         checkPointerWidths(valueArray* FL_NONNULL items, size_t writePos);
+        void         fixPointers(valueArray* FL_NONNULL items);
+        void         endCollection(internal::tags tag);
+        void         push(internal::tags tag, size_t reserve);
+        inline void  pop();
+        void         writeKey(int);
+        void         writeValue(const Value* FL_NONNULL, const WriteValueFunc*);
+        void         writeValue(const Value* FL_NONNULL, const SharedKeys*&, const WriteValueFunc*);
+        const Value* minUsed(const Value* value);
 
-        Encoder(const Encoder&) = delete;
+                 Encoder(const Encoder&)   = delete;
         Encoder& operator=(const Encoder&) = delete;
 
         //////// Data members:
 
         static constexpr size_t kInitialStringTableSize = 32;
 
-        Writer _out;                 // Where output is written to
-        valueArray *_items;          // Values of currently-open array/dict; == &_stack[_stackDepth-1]
-        smallVector<valueArray, kInitialStackSize> _stack; // Stack of open arrays/dicts
-        unsigned _stackDepth;        // Current depth of _stack
-        PreallocatedStringTable<kInitialStringTableSize> _strings; // Maps strings to the offsets where they appear as values
-        Writer _stringStorage;       // Backing store for strings in _strings
-        bool _uniqueStrings {true};  // Should strings be uniqued before writing?
-        Retained<SharedKeys> _sharedKeys;  // Client-provided key-to-int mapping
-        slice _base;                 // Base Fleece data being appended to (if any)
-        alloc_slice _ownedBase;      // If I allocated _base, it's stored here too to retain it
-        const void* _baseCutoff {0}; // Lowest addr in _base that I can write a ptr to
-        const void* _baseMinUsed {0};// Lowest addr in _base I've written a ptr to
-        int _copyingCollection {0};  // Nonzero inside writeValue when writing array/dict
-        bool _writingKey    {false}; // True if Value being written is a key
-        bool _blockedOnKey  {false}; // True if writes should be refused
-        bool _trailer       {true};  // Write standard trailer at end?
-        bool _markExternPtrs{false}; // Mark pointers outside encoded data as 'extern'
+        Writer      _out;    // Where output is written to
+        valueArray* _items;  // Values of currently-open array/dict; == &_stack[_stackDepth-1]
+        smallVector<valueArray, kInitialStackSize> _stack;       // Stack of open arrays/dicts
+        unsigned                                   _stackDepth;  // Current depth of _stack
+        PreallocatedStringTable<kInitialStringTableSize>
+                             _strings;                // Maps strings to the offsets where they appear as values
+        Writer               _stringStorage;          // Backing store for strings in _strings
+        bool                 _uniqueStrings{true};    // Should strings be uniqued before writing?
+        Retained<SharedKeys> _sharedKeys;             // Client-provided key-to-int mapping
+        slice                _base;                   // Base Fleece data being appended to (if any)
+        alloc_slice          _ownedBase;              // If I allocated _base, it's stored here too to retain it
+        const void*          _baseCutoff{0};          // Lowest addr in _base that I can write a ptr to
+        const void*          _baseMinUsed{0};         // Lowest addr in _base I've written a ptr to
+        int                  _copyingCollection{0};   // Nonzero inside writeValue when writing array/dict
+        bool                 _writingKey{false};      // True if Value being written is a key
+        bool                 _blockedOnKey{false};    // True if writes should be refused
+        bool                 _trailer{true};          // Write standard trailer at end?
+        bool                 _markExternPtrs{false};  // Mark pointers outside encoded data as 'extern'
 
         friend class EncoderTests;
 #ifndef NDEBUG
-    public: // Statistics for use in tests
-        unsigned _numNarrow {0}, _numWide {0}, _narrowCount {0}, _wideCount {0},
-                 _numSavedStrings {0};
+      public:  // Statistics for use in tests
+        unsigned _numNarrow{0}, _numWide{0}, _narrowCount{0}, _wideCount{0}, _numSavedStrings{0};
 #endif
     };
 
-} }
+}}  // namespace fleece::impl

--- a/Fleece/Core/JSONConverter.hh
+++ b/Fleece/Core/JSONConverter.hh
@@ -18,16 +18,16 @@
 #include "fleece/slice.hh"
 
 extern "C" {
-    struct jsonsl_state_st;
-    struct jsonsl_st;
+struct jsonsl_state_st;
+struct jsonsl_st;
 }
 
 namespace fleece { namespace impl {
 
     /** Parses JSON data and writes the values in it to a Fleece encoder. */
     class JSONConverter {
-    public:
-        JSONConverter(Encoder&) noexcept;
+      public:
+         JSONConverter(Encoder&) noexcept;
         ~JSONConverter();
 
         /** Parses JSON data and writes the values to the encoder.
@@ -35,42 +35,41 @@ namespace fleece { namespace impl {
         bool encodeJSON(slice json);
 
         /** See jsonsl_error_t for error codes, plus a few more defined below. */
-        int jsonError() noexcept                {return _jsonError;}
-        ErrorCode errorCode() noexcept          {return _errorCode;}
+        int jsonError() noexcept { return _jsonError; }
+
+        ErrorCode errorCode() noexcept { return _errorCode; }
+
         const char* errorMessage() noexcept;
-        
+
         /** Byte offset in input where error occurred */
-        size_t errorPos() noexcept              {return _errorPos;}
+        size_t errorPos() noexcept { return _errorPos; }
 
         /** Extra error codes beyond those in jsonsl_error_t. */
-        enum {
-            kErrTruncatedJSON = 1000,
-            kErrExceptionThrown
-        };
+        enum { kErrTruncatedJSON = 1000, kErrExceptionThrown };
 
         /** Resets the converter, as though you'd deleted it and constructed a new one. */
         void reset();
 
         /** Convenience method to convert JSON to Fleece data. Throws FleeceException on error. */
-        static alloc_slice convertJSON(slice json, SharedKeys *sk =nullptr);
+        static alloc_slice convertJSON(slice json, SharedKeys* sk = nullptr);
 
-    //private:
-        void push(struct jsonsl_state_st *state NONNULL);
-        void pop(struct jsonsl_state_st *state NONNULL);
-        int gotError(int err, size_t pos) noexcept;
-        int gotError(int err, const char *errat) noexcept;
-        void gotException(ErrorCode code, const char *what NONNULL, size_t pos) noexcept;
+        //private:
+        void push(struct jsonsl_state_st* FL_NONNULL state);
+        void pop(struct jsonsl_state_st* FL_NONNULL state);
+        int  gotError(int err, size_t pos) noexcept;
+        int  gotError(int err, const char* errat) noexcept;
+        void gotException(ErrorCode code, const char* FL_NONNULL what, size_t pos) noexcept;
 
-    private:
-        void writeDouble(struct jsonsl_state_st *);
+      private:
+        void writeDouble(struct jsonsl_state_st*);
 
-        Encoder &_encoder;                  // encoder to write to
-        struct jsonsl_st * _jsn {nullptr};  // JSON parser
-        int _jsonError {0};                 // Parse error from jsonsl
-        ErrorCode _errorCode {NoError};
-        std::string _errorMessage;
-        size_t _errorPos {0};               // Byte index where parse error occurred
-        slice _input;                       // Current JSON being parsed
+        Encoder&          _encoder;       // encoder to write to
+        struct jsonsl_st* _jsn{nullptr};  // JSON parser
+        int               _jsonError{0};  // Parse error from jsonsl
+        ErrorCode         _errorCode{NoError};
+        std::string       _errorMessage;
+        size_t            _errorPos{0};  // Byte index where parse error occurred
+        slice             _input;        // Current JSON being parsed
     };
 
-} }
+}}  // namespace fleece::impl

--- a/Fleece/Core/JSONDelta.cc
+++ b/Fleece/Core/JSONDelta.cc
@@ -282,7 +282,7 @@ namespace fleece { namespace impl {
     }
 
 
-    inline void JSONDelta::_applyArray(const Value *old, const Array* NONNULL delta) {
+    inline void JSONDelta::_applyArray(const Value *old, const Array* FL_NONNULL delta) {
         switch (delta->count()) {
             case 0:
                 // Deletion:
@@ -330,7 +330,7 @@ namespace fleece { namespace impl {
     }
 
 
-    inline void JSONDelta::_patchDict(const Dict* NONNULL old, const Dict* NONNULL delta) {
+    inline void JSONDelta::_patchDict(const Dict* FL_NONNULL old, const Dict* FL_NONNULL delta) {
         // Dict: Incremental update
         if (_decoder->valueIsInBase(old)) {
             // If the old dict is in the base, we can create an inherited dict:
@@ -372,7 +372,7 @@ namespace fleece { namespace impl {
     }
 
 
-    inline void JSONDelta::_patchArray(const Array* NONNULL old, const Dict* NONNULL delta) {
+    inline void JSONDelta::_patchArray(const Array* FL_NONNULL old, const Dict* FL_NONNULL delta) {
         // Array: Incremental update
         _decoder->beginArray();
         uint32_t index = 0;

--- a/Fleece/Core/JSONDelta.hh
+++ b/Fleece/Core/JSONDelta.hh
@@ -56,10 +56,10 @@ namespace fleece { namespace impl {
         bool _write(const Value *old, const Value *nuu, pathItem *path);
 
         JSONDelta(Encoder&);
-        void _apply(const Value *old, const Value* NONNULL delta);
-        void _applyArray(const Value* old, const Array* NONNULL delta);
-        void _patchArray(const Array* NONNULL old, const Dict* NONNULL delta);
-        void _patchDict(const Dict* NONNULL old, const Dict* NONNULL delta);
+        void _apply(const Value *old, const Value* FL_NONNULL delta);
+        void _applyArray(const Value* old, const Array* FL_NONNULL delta);
+        void _patchArray(const Array* FL_NONNULL old, const Dict* FL_NONNULL delta);
+        void _patchDict(const Dict* FL_NONNULL old, const Dict* FL_NONNULL delta);
 
         void writePath(pathItem*);
         static bool isDeltaDeletion(const Value *delta);

--- a/Fleece/Core/Path.hh
+++ b/Fleece/Core/Path.hh
@@ -30,49 +30,52 @@ namespace fleece { namespace impl {
         A '\' can be used to escape a special character ('.', '[' or '$') at the start of a
         property name (but not yet in the middle of a name.) */
     class Path {
-    public:
+      public:
         class Element;
 
         //// Construction from a string: (throws FleeceException with code PathSyntaxError)
 
-        Path(slice specifier)                       {addComponents(specifier);}
+        Path(slice specifier) { addComponents(specifier); }
 
         //// Step-by-step construction:
 
-        Path()                                      =default;
+             Path() = default;
         void addProperty(slice key);
         void addIndex(int index);
         void addComponents(slice components);
 
-        bool operator== (const Path&) const;
-        bool operator!= (const Path& other) const      {return !(*this == other);}
+        bool operator==(const Path&) const;
 
-        Path& operator += (const Path&);
-        void drop(size_t numToDropFromStart);
+        bool operator!=(const Path& other) const { return !(*this == other); }
+
+        Path& operator+=(const Path&);
+        void  drop(size_t numToDropFromStart);
 
         //// Path element accessors:
 
-        const smallVector<Element,4>& path() const      {return _path;}
-        smallVector<Element,4>& path()                  {return _path;}
-        bool empty() const                              {return _path.empty();}
-        size_t size() const                             {return _path.size();}
+        const smallVector<Element, 4>& path() const { return _path; }
 
-        const Element& operator[] (size_t i) const      {return _path[i];}
-        Element& operator[] (size_t i)                  {return _path[i];}
+        smallVector<Element, 4>& path() { return _path; }
+
+        bool empty() const { return _path.empty(); }
+
+        size_t size() const { return _path.size(); }
+
+        const Element& operator[](size_t i) const { return _path[i]; }
+
+        Element& operator[](size_t i) { return _path[i]; }
 
         //// Evaluation:
 
-        const Value* eval(const Value *root) const noexcept;
+        const Value* eval(const Value* root) const noexcept;
 
         /** One-shot evaluation; faster if you're only doing it once */
-        static const Value* eval(slice specifier,
-                                 const Value *root NONNULL);
+        static const Value* eval(slice specifier, const Value* FL_NONNULL root);
 
         /** Evaluates a JSONPointer string (RFC 6901), which has a different syntax.
             This can only be done one-shot since JSONPointer path components are ambiguous unless
             the actual JSON is present (a number could be an array index or dict key.) */
-        static const Value* evalJSONPointer(slice specifier,
-                                            const Value* root NONNULL);
+        static const Value* evalJSONPointer(slice specifier, const Value* FL_NONNULL root);
 
         //// Converting to string:
 
@@ -84,41 +87,45 @@ namespace fleece { namespace impl {
             It will add a backslash before any '.' and '[' characters.
             If `first` is true it will also backslash-escape a leading '$'.
             If `first` is false, it will prefix a '.'. */
-        static void writeProperty(std::ostream&, slice key, bool first =false);
+        static void writeProperty(std::ostream&, slice key, bool first = false);
 
         /** Utility for writing a path component to a stream. */
         static void writeIndex(std::ostream&, int arrayIndex);
 
-
         /** An element of a Path, representing either a named property or an array index. */
         class Element {
-        public:
+          public:
             Element(slice property);
-            Element(int32_t arrayIndex)             :_index(arrayIndex) { }
-            Element(const Element &e);
-            bool operator== (const Element &e) const;
-            bool isKey() const                      {return _key != nullptr;}
-            Dict::key& key() const                  {return *_key;}
-            slice keyStr() const                    {return _key ? _key->string() : slice();}
-            int32_t index() const                   {return _index;}
 
-            const Value* eval(const Value* NONNULL) const noexcept;
-            static const Value* eval(char token, slice property, int32_t index,
-                                     const Value *item NONNULL) noexcept;
+            Element(int32_t arrayIndex) : _index(arrayIndex) {}
 
-        private:
-            static const Value* getFromArray(const Value* NONNULL, int32_t index) noexcept;
+                 Element(const Element& e);
+            bool operator==(const Element& e) const;
 
-            alloc_slice _keyBuf;
-            std::unique_ptr<Dict::key> _key {nullptr};
-            int32_t _index {0};
+            bool isKey() const { return _key != nullptr; }
+
+            Dict::key& key() const { return *_key; }
+
+            slice keyStr() const { return _key ? _key->string() : slice(); }
+
+            int32_t index() const { return _index; }
+
+            const Value*        eval(const Value* FL_NONNULL) const noexcept;
+            static const Value* eval(char token, slice property, int32_t index, const Value* FL_NONNULL item) noexcept;
+
+          private:
+            static const Value* getFromArray(const Value* FL_NONNULL, int32_t index) noexcept;
+
+            alloc_slice                _keyBuf;
+            std::unique_ptr<Dict::key> _key{nullptr};
+            int32_t                    _index{0};
         };
 
-    private:
-        using eachComponentCallback = function_ref<bool(char,slice,int32_t)>;
+      private:
+        using eachComponentCallback = function_ref<bool(char, slice, int32_t)>;
         static void forEachComponent(slice in, bool atStart, eachComponentCallback);
 
         smallVector<Element, 4> _path;
     };
 
-} }
+}}  // namespace fleece::impl

--- a/Fleece/Mutable/HeapArray.hh
+++ b/Fleece/Mutable/HeapArray.hh
@@ -79,8 +79,8 @@ namespace fleece { namespace impl { namespace internal {
 
         class iterator {
         public:
-            iterator(const HeapArray* NONNULL) noexcept;
-            iterator(const MutableArray* NONNULL) noexcept;
+            iterator(const HeapArray* FL_NONNULL) noexcept;
+            iterator(const MutableArray* FL_NONNULL) noexcept;
 
             const Value* value() const noexcept             {return _value;}
 

--- a/Fleece/Mutable/HeapDict.hh
+++ b/Fleece/Mutable/HeapDict.hh
@@ -72,8 +72,8 @@ namespace fleece { namespace impl { namespace internal {
 
         class iterator {
         public:
-            iterator(const HeapDict* NONNULL) noexcept;
-            iterator(const MutableDict* NONNULL) noexcept;
+            iterator(const HeapDict* FL_NONNULL) noexcept;
+            iterator(const MutableDict* FL_NONNULL) noexcept;
 
             uint32_t count() const noexcept                 {return _count;}
             

--- a/Fleece/Support/Backtrace.cc
+++ b/Fleece/Support/Backtrace.cc
@@ -321,7 +321,7 @@ namespace fleece {
         free(_symbols);
     }
 
-    std::string Unmangle(const char *name NONNULL) {
+    std::string Unmangle(const char* FL_NONNULL name) {
         auto unmangled = unmangle(name);
         std::string result = unmangled;
         if (unmangled != name)

--- a/Fleece/Support/Backtrace.hh
+++ b/Fleece/Support/Backtrace.hh
@@ -23,14 +23,14 @@ namespace fleece {
 
     /** Captures a backtrace of the current thread, and can convert it to human-readable form. */
     class Backtrace {
-    public:
+      public:
         /// Captures a backtrace and returns a shared pointer to the instance.
-        static std::shared_ptr<Backtrace> capture(unsigned skipFrames =0, unsigned maxFrames =50);
+        static std::shared_ptr<Backtrace> capture(unsigned skipFrames = 0, unsigned maxFrames = 50);
 
         /// Captures a backtrace, unless maxFrames is zero.
         /// @param skipFrames  Number of frames to skip at top of stack
         /// @param maxFrames  Maximum number of frames to capture
-        explicit Backtrace(unsigned skipFrames =0, unsigned maxFrames =50);
+        explicit Backtrace(unsigned skipFrames = 0, unsigned maxFrames = 50);
 
         ~Backtrace();
 
@@ -46,18 +46,19 @@ namespace fleece {
         // Direct access to stack frames:
 
         struct frameInfo {
-            const void* pc;         ///< Program counter
-            size_t offset;          ///< Byte offset of pc in function
-            const char *function;   ///< Name of (nearest) known function
-            const char *library;    ///< Name of dynamic library containing the function
+            const void* pc;        ///< Program counter
+            size_t      offset;    ///< Byte offset of pc in function
+            const char* function;  ///< Name of (nearest) known function
+            const char* library;   ///< Name of dynamic library containing the function
         };
 
         /// The number of stack frames captured.
-        unsigned size() const                   {return (unsigned)_addrs.size();}
+        unsigned size() const { return (unsigned)_addrs.size(); }
 
         /// Returns info about a stack frame. 0 is the top.
         frameInfo getFrame(unsigned) const;
-        frameInfo operator[] (unsigned i)       {return getFrame(i);}
+
+        frameInfo operator[](unsigned i) { return getFrame(i); }
 
         /// Installs a C++ terminate_handler that will log a backtrace and info about any uncaught
         /// exception. By default it then calls the preexisting terminate_handler, which usually
@@ -69,24 +70,23 @@ namespace fleece {
         /// Only the first call to this function has any effect; subsequent calls are ignored.
         static void installTerminateHandler(std::function<void(const std::string&)> logger);
 
-    private:
-        void _capture(unsigned skipFrames =0, unsigned maxFrames =50);
-        char* printFrame(unsigned i) const;
+      private:
+        void        _capture(unsigned skipFrames = 0, unsigned maxFrames = 50);
+        char*       printFrame(unsigned i) const;
         static void writeCrashLog(std::ostream&);
 
-        std::vector<void*> _addrs;          // Array of PCs in backtrace, top first
-        char** _symbols { nullptr };
+        std::vector<void*> _addrs;  // Array of PCs in backtrace, top first
+        char**             _symbols{nullptr};
     };
-
 
     /// Attempts to return the unmangled name of the type. (If it fails, returns the mangled name.)
     std::string Unmangle(const std::type_info&);
 
     /// Attempts to unmangle a name. (If it fails, returns the input string unaltered.)
-    std::string Unmangle(const char *name NONNULL);
+    std::string Unmangle(const char* FL_NONNULL name);
 
     /// Returns the name of the function at the given address, or an empty string if none.
     /// The name will be unmangled, if possible.
-    std::string FunctionName(const void *pc);
+    std::string FunctionName(const void* pc);
 
-}
+}  // namespace fleece

--- a/Fleece/Support/NumConversion.cc
+++ b/Fleece/Support/NumConversion.cc
@@ -29,7 +29,7 @@ namespace fleece {
     }
 
     // subroutine that parses only digits
-    static bool _parseUInt(const char *str NONNULL, uint64_t &result, bool allowTrailing) {
+    static bool _parseUInt(const char* FL_NONNULL str, uint64_t &result, bool allowTrailing) {
         uint64_t n = 0;
         if (!isdigit(*str))
             return false;
@@ -49,7 +49,7 @@ namespace fleece {
     }
 
     // Unsigned version:
-    bool ParseInteger(const char *str NONNULL, uint64_t &result, bool allowTrailing) {
+    bool ParseInteger(const char* FL_NONNULL str, uint64_t &result, bool allowTrailing) {
         while (isspace(*str))
             ++str;
         if (*str == '+')
@@ -59,7 +59,7 @@ namespace fleece {
 
 
     // Signed version:
-    bool ParseInteger(const char *str NONNULL, int64_t &result, bool allowTrailing) {
+    bool ParseInteger(const char* FL_NONNULL str, int64_t &result, bool allowTrailing) {
         while (isspace(*str))
             ++str;
         bool negative = (*str == '-');
@@ -96,7 +96,7 @@ namespace fleece {
     }
 
 
-    bool ParseDouble(const char *str NONNULL, double &result, bool allowTrailing) {
+    bool ParseDouble(const char* FL_NONNULL str, double &result, bool allowTrailing) {
         char *endptr;
         // strtod is locale-aware, so in some locales it will not interpret '.' as a decimal point.
         // To work around that, use the C locale explicitly.

--- a/Fleece/Support/NumConversion.hh
+++ b/Fleece/Support/NumConversion.hh
@@ -14,9 +14,9 @@
 #include "fleece/PlatformCompat.hh"
 
 #if __has_include("Error.hh")
-#include "Error.hh"
+#    include "Error.hh"
 #else
-#include "FleeceException.hh"
+#    include "FleeceException.hh"
 #endif
 
 #include <cstddef>
@@ -32,84 +32,85 @@ namespace fleece {
     /// to fit in an `int64_t`.
     /// Expected: optional whitespace, an optional '-' or '+',  one or more decimal digits.
     /// If `allowTrailing` is false it also rejects anything but whitespace after the last digit.
-    bool ParseInteger(const char *str NONNULL, int64_t &result, bool allowTrailing =false);
+    bool ParseInteger(const char* FL_NONNULL str, int64_t& result, bool allowTrailing = false);
 
     /// Parse `str` as an unsigned integer, storing the result in `result` and returning true.
     /// Returns false if the string is not a valid unsigned integer, or if the result is too large
     /// to fit in a `uint64_t`.
     /// Expected: optional whitespace, an optional '+', one or more decimal digits.
     /// If `allowTrailing` is false it also rejects anything but whitespace after the last digit.
-    bool ParseInteger(const char *str NONNULL, uint64_t &result, bool allowTrailing =false);
+    bool ParseInteger(const char* FL_NONNULL str, uint64_t& result, bool allowTrailing = false);
 
     /// Alternative syntax for parsing an unsigned integer.
-    static inline bool ParseUnsignedInteger(const char *str NONNULL, uint64_t &r, bool t =false) {
+    static inline bool ParseUnsignedInteger(const char* FL_NONNULL str, uint64_t& r, bool t = false) {
         return ParseInteger(str, r, t);
     }
-
 
     /// Parse `str` as a floating-point number, storing the result in `result` and returning true.
     /// If `allowTrailing` is false, returns false if there's anything but whitespace after the
     /// last digit.
-    bool ParseDouble(const char *str NONNULL, double &result, bool allowTrailing =false);
-    
+    bool ParseDouble(const char* FL_NONNULL str, double& result, bool allowTrailing = false);
+
     /// Parse `str` as a floating-point number, reading as many digits as possible.
     /// (I.e. non-numeric characters after the digits are not treated as an error.)
     /// If no digits are parseable, returns 0.0.
-    double ParseDouble(const char *str NONNULL) noexcept;
+    double ParseDouble(const char* FL_NONNULL str) noexcept;
 
 
     /// Format a 64-bit-floating point number to a string.
-    size_t WriteFloat(double n, char *dst, size_t capacity);
+    size_t WriteFloat(double n, char* dst, size_t capacity);
 
     /// Format a 32-bit floating-point number to a string.
-    size_t WriteFloat(float n, char *dst, size_t capacity);
+    size_t WriteFloat(float n, char* dst, size_t capacity);
 
     /// Alternative syntax for formatting a 64-bit-floating point number to a string.
-    static inline size_t WriteDouble(double n, char *dst, size_t c)  {return WriteFloat(n, dst, c);}
+    static inline size_t WriteDouble(double n, char* dst, size_t c) { return WriteFloat(n, dst, c); }
 
-    #if DEBUG
-        template<typename Out, typename In>
-        static Out narrow_cast (In val) {
-            static_assert(::std::is_arithmetic<In>::value && ::std::is_arithmetic<Out>::value, "Only numeric types are valid for narrow_cast");
-            if constexpr(sizeof(In) <= sizeof(Out) && ::std::is_signed<In>::value == ::std::is_signed<Out>::value) {
-                return (Out)val;
-            }
-
-            // Comparing an unsigned number against a signed minimum causes issues, at least on Windows,
-            // but if the output is signed and the input is unsigned then there is never a case where
-            // the input could underflow the output.  The reverse situation does not appear to be true.
-            // the input could underflow the output.  The reverse situation does not appear to be true.
-            bool min_ok = std::is_signed<Out>::value && !std::is_signed<In>::value;
-
-#ifdef Assert
-            if constexpr (::std::is_floating_point<In>::value) {
-                Assert(val >= std::numeric_limits<Out>::min() && val <= ::std::numeric_limits<Out>::max(),
-                    "Invalid narrow_cast %g -> %s", (double)val, typeid(Out).name());
-            } else if constexpr(::std::is_signed<In>::value) {
-                Assert((min_ok || val >= std::numeric_limits<Out>::min()) && val <= ::std::numeric_limits<Out>::max(),
-                    "Invalid narrow_cast %" PRIi64 " -> %s", (int64_t)val, typeid(Out).name());
-            } else {
-                Assert((min_ok || val >= std::numeric_limits<Out>::min()) && val <= ::std::numeric_limits<Out>::max(), 
-                    "Invalid narrow_cast %" PRIu64 " -> %s", (uint64_t)val, typeid(Out).name());
-            }
-#else
-            if constexpr(::std::is_floating_point<In>::value) {
-                throwIf(val < std::numeric_limits<Out>::min() || val > std::numeric_limits<Out>::max(), InternalError, "Invalid narrow_cast %g -> %s", (double)val, typeid(Out).name());
-            } else if constexpr(::std::is_signed<In>::value) {
-                throwIf((!min_ok && val < std::numeric_limits<Out>::min()) || val > std::numeric_limits<Out>::max(),
-                    InternalError, "Invalid narrow_cast %" PRIi64 " -> %s", (int64_t)val, typeid(Out).name());
-            } else {
-                throwIf((!min_ok && val < std::numeric_limits<Out>::min()) || val > std::numeric_limits<Out>::max(),
-                    InternalError, "Invalid narrow_cast %" PRIu64 " -> %s", (uint64_t)val, typeid(Out).name());
-            }
-#endif
+#if DEBUG
+    template <typename Out, typename In>
+    static Out narrow_cast(In val) {
+        static_assert(::std::is_arithmetic<In>::value && ::std::is_arithmetic<Out>::value,
+                      "Only numeric types are valid for narrow_cast");
+        if constexpr ( sizeof(In) <= sizeof(Out) && ::std::is_signed<In>::value == ::std::is_signed<Out>::value ) {
             return (Out)val;
         }
-    #else
-        template<typename Out, typename In>
-        static inline Out narrow_cast(In val) {
-            return static_cast<Out>(val);
-        }
-    #endif
 
-}
+        // Comparing an unsigned number against a signed minimum causes issues, at least on Windows,
+        // but if the output is signed and the input is unsigned then there is never a case where
+        // the input could underflow the output.  The reverse situation does not appear to be true.
+        // the input could underflow the output.  The reverse situation does not appear to be true.
+        bool min_ok = std::is_signed<Out>::value && !std::is_signed<In>::value;
+
+#    ifdef Assert
+        if constexpr ( ::std::is_floating_point<In>::value ) {
+            Assert(val >= std::numeric_limits<Out>::min() && val <= ::std::numeric_limits<Out>::max(),
+                   "Invalid narrow_cast %g -> %s", (double)val, typeid(Out).name());
+        } else if constexpr ( ::std::is_signed<In>::value ) {
+            Assert((min_ok || val >= std::numeric_limits<Out>::min()) && val <= ::std::numeric_limits<Out>::max(),
+                   "Invalid narrow_cast %" PRIi64 " -> %s", (int64_t)val, typeid(Out).name());
+        } else {
+            Assert((min_ok || val >= std::numeric_limits<Out>::min()) && val <= ::std::numeric_limits<Out>::max(),
+                   "Invalid narrow_cast %" PRIu64 " -> %s", (uint64_t)val, typeid(Out).name());
+        }
+#    else
+        if constexpr ( ::std::is_floating_point<In>::value ) {
+            throwIf(val < std::numeric_limits<Out>::min() || val > std::numeric_limits<Out>::max(), InternalError,
+                    "Invalid narrow_cast %g -> %s", (double)val, typeid(Out).name());
+        } else if constexpr ( ::std::is_signed<In>::value ) {
+            throwIf((!min_ok && val < std::numeric_limits<Out>::min()) || val > std::numeric_limits<Out>::max(),
+                    InternalError, "Invalid narrow_cast %" PRIi64 " -> %s", (int64_t)val, typeid(Out).name());
+        } else {
+            throwIf((!min_ok && val < std::numeric_limits<Out>::min()) || val > std::numeric_limits<Out>::max(),
+                    InternalError, "Invalid narrow_cast %" PRIu64 " -> %s", (uint64_t)val, typeid(Out).name());
+        }
+#    endif
+        return (Out)val;
+    }
+#else
+    template <typename Out, typename In>
+    static inline Out narrow_cast(In val) {
+        return static_cast<Out>(val);
+    }
+#endif
+
+}  // namespace fleece

--- a/Fleece/Support/varint.hh
+++ b/Fleece/Support/varint.hh
@@ -15,110 +15,99 @@
 
 namespace fleece {
 
-    
+
 #pragma mark - UNSIGNED VARINTS:
 
-// Based on varint implementation from the Go language (src/pkg/encoding/binary/varint.go)
-// This file implements "varint" encoding of unsigned 64-bit integers.
-// The encoding is:
-// - unsigned integers are serialized 7 bits at a time, starting with the
-//   least significant bits
-// - the most significant bit (msb) in each output byte indicates if there
-//   is a continuation byte (msb = 1)
-// (This implementation does not support signed integers, which have a more complex encoding.)
+    // Based on varint implementation from the Go language (src/pkg/encoding/binary/varint.go)
+    // This file implements "varint" encoding of unsigned 64-bit integers.
+    // The encoding is:
+    // - unsigned integers are serialized 7 bits at a time, starting with the
+    //   least significant bits
+    // - the most significant bit (msb) in each output byte indicates if there
+    //   is a continuation byte (msb = 1)
+    // (This implementation does not support signed integers, which have a more complex encoding.)
 
 
-/** MaxVarintLenN is the maximum length of a varint-encoded N-bit integer. */
-enum {
-    kMaxVarintLen16 = 3,
-    kMaxVarintLen32 = 5,
-    kMaxVarintLen64 = 10,
-};
+    /** MaxVarintLenN is the maximum length of a varint-encoded N-bit integer. */
+    enum {
+        kMaxVarintLen16 = 3,
+        kMaxVarintLen32 = 5,
+        kMaxVarintLen64 = 10,
+    };
 
-/** Returns the number of bytes needed to encode a specific integer. */
-size_t SizeOfVarInt(uint64_t n);
+    /** Returns the number of bytes needed to encode a specific integer. */
+    size_t SizeOfVarInt(uint64_t n);
 
-/** Encodes n as a varint, writing it to buf. Returns the number of bytes written. */
-size_t PutUVarInt(void *buf NONNULL, uint64_t n);
+    /** Encodes n as a varint, writing it to buf. Returns the number of bytes written. */
+    size_t PutUVarInt(void* FL_NONNULL buf, uint64_t n);
 
-size_t _GetUVarInt(slice buf, uint64_t *n NONNULL);   // do not call directly
-size_t _GetUVarInt32(slice buf, uint32_t *n NONNULL); // do not call directly
+    size_t _GetUVarInt(slice buf, uint64_t* FL_NONNULL n);    // do not call directly
+    size_t _GetUVarInt32(slice buf, uint32_t* FL_NONNULL n);  // do not call directly
 
-    
-/** Decodes a varint from the bytes in buf, storing it into *n.
+    /** Decodes a varint from the bytes in buf, storing it into *n.
     Returns the number of bytes read, or 0 if the data is invalid (buffer too short or number
     too long.) */
-__hot
-static inline size_t GetUVarInt(slice buf, uint64_t *n NONNULL) {
-    if (_usuallyFalse(buf.size == 0))
-        return 0;
-    uint8_t byte = buf[0];
-    if (_usuallyTrue(byte < 0x80)) {
-        *n = byte;
-        return 1;
+    __hot static inline size_t GetUVarInt(slice buf, uint64_t* FL_NONNULL n) {
+        if ( _usuallyFalse(buf.size == 0) ) return 0;
+        uint8_t byte = buf[0];
+        if ( _usuallyTrue(byte < 0x80) ) {
+            *n = byte;
+            return 1;
+        }
+        return _GetUVarInt(buf, n);
     }
-    return _GetUVarInt(buf, n);
-}
 
-
-/** Decodes a varint from the bytes in buf, storing it into *n.
+    /** Decodes a varint from the bytes in buf, storing it into *n.
     Returns the number of bytes read, or 0 if the data is invalid (buffer too short or number
     too long.) */
-__hot
-static inline size_t GetUVarInt32(slice buf, uint32_t *n NONNULL) {
-    if (_usuallyFalse(buf.size == 0))
-        return 0;
-    uint8_t byte = buf[0];
-    if (_usuallyTrue(byte < 0x80)) {
-        *n = byte;
-        return 1;
+    __hot static inline size_t GetUVarInt32(slice buf, uint32_t* FL_NONNULL n) {
+        if ( _usuallyFalse(buf.size == 0) ) return 0;
+        uint8_t byte = buf[0];
+        if ( _usuallyTrue(byte < 0x80) ) {
+            *n = byte;
+            return 1;
+        }
+        return _GetUVarInt32(buf, n);
     }
-    return _GetUVarInt32(buf, n);
-}
 
-
-/** Skips a pointer past a varint without decoding it. */
-__hot
-static inline const void* SkipVarInt(const void *buf NONNULL) {
-    auto p = (const uint8_t*)buf;
-    uint8_t byte;
-    do {
-        byte = *p++;
-    } while (byte & 0x80);
-    return p;
-}
-
+    /** Skips a pointer past a varint without decoding it. */
+    __hot static inline const void* SkipVarInt(const void* FL_NONNULL buf) {
+        auto    p = (const uint8_t*)buf;
+        uint8_t byte;
+        do { byte = *p++; } while ( byte & 0x80 );
+        return p;
+    }
 
 #pragma mark - VARIABLE LENGTH INTS:
 
-// This is a compact encoding that requires the length to be stored externally.
+    // This is a compact encoding that requires the length to be stored externally.
 
-/** Encodes an integer `n` to `buf` and returns the number of bytes used (1-8).
+    /** Encodes an integer `n` to `buf` and returns the number of bytes used (1-8).
     if `isUnsigned` is true, the number is treated as unsigned (uint64_t.) */
-size_t PutIntOfLength(void *buf NONNULL, int64_t n, bool isUnsigned =false);
+    size_t PutIntOfLength(void* FL_NONNULL buf, int64_t n, bool isUnsigned = false);
 
-/** Encodes an unsigned integer `n` to `buf` and returns the number of bytes used (1-8). */
-inline size_t PutUIntOfLength(void *buf NONNULL, uint64_t n) {return PutIntOfLength(buf, n, true);}
+    /** Encodes an unsigned integer `n` to `buf` and returns the number of bytes used (1-8). */
+    inline size_t PutUIntOfLength(void* FL_NONNULL buf, uint64_t n) { return PutIntOfLength(buf, n, true); }
 
-/** Returns a signed integer decoded from `length` bytes starting at `buf`. */
-int64_t GetIntOfLength(const void *buf NONNULL, unsigned length);
+    /** Returns a signed integer decoded from `length` bytes starting at `buf`. */
+    int64_t GetIntOfLength(const void* FL_NONNULL buf, unsigned length);
 
 
 #pragma mark - COLLATABLE INTS:
 
-// Collatable ints use an encoding that can be compared using memcmp().
+    // Collatable ints use an encoding that can be compared using memcmp().
 
-static constexpr size_t kMaxCollatableUIntLen64 = 9;
+    static constexpr size_t kMaxCollatableUIntLen64 = 9;
 
-/** Returns the number of bytes needed to encode a specific integer. */
-size_t SizeOfCollatableUInt(uint64_t n);
+    /** Returns the number of bytes needed to encode a specific integer. */
+    size_t SizeOfCollatableUInt(uint64_t n);
 
-/** Encodes n as a collatable int, writing it to buf. Returns the number of bytes written. */
-size_t PutCollatableUInt(void *buf, uint64_t n);
+    /** Encodes n as a collatable int, writing it to buf. Returns the number of bytes written. */
+    size_t PutCollatableUInt(void* buf, uint64_t n);
 
-/** Decodes a collatable int from the bytes in buf, storing it into *n.
+    /** Decodes a collatable int from the bytes in buf, storing it into *n.
     Returns the number of bytes read, or 0 if the data is invalid (buffer too short or number
     too long.) */
-size_t GetCollatableUInt(slice buf, uint64_t *n NONNULL);
+    size_t GetCollatableUInt(slice buf, uint64_t* FL_NONNULL n);
 
-}
+}  // namespace fleece


### PR DESCRIPTION
Many of the warnings that nonnull GCC spews out seem to come from Fleece. 
Looks like there's a TODO item to replace NONNULL with FL_NONULL, so I've done that. 
Hopefully that addresses the GCC warnings.