### PR TITLE
Fix FLEncoder_GetErrorMessage call after FLEncoder_Finish [#229]

### DIFF
--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -719,7 +719,7 @@ FLError FLEncoder_GetError(FLEncoder e) FLAPI {
 }
 
 const char* FL_NULLABLE FLEncoder_GetErrorMessage(FLEncoder e) FLAPI {
-    return e->hasError() ? e->errorMessage.c_str() : nullptr;
+    return e->errorMessage.empty() ? nullptr : e->errorMessage.c_str();
 }
 
 void FLEncoder_SetExtraInfo(FLEncoder e, void* FL_NULLABLE info) FLAPI {

--- a/Tests/API_ValueTests.cc
+++ b/Tests/API_ValueTests.cc
@@ -119,6 +119,21 @@ TEST_CASE("API Encoder", "[API][Encoder]") {
 }
 
 
+TEST_CASE("API Encoder Error", "[API][Encoder][!throws]") {
+    // Test fix for #229
+    FLEncoder enc = FLEncoder_New();
+    CHECK_FALSE(FLEncoder_WriteKey(enc, "oops"_sl));   // writing key outside of a dict
+    FLError error = {};
+    FLSliceResult data = FLEncoder_Finish(enc, &error);
+    CHECK(data.buf == nullptr);
+    CHECK(error == kFLEncodeError);
+    const char* errorMessage = FLEncoder_GetErrorMessage(enc);
+    REQUIRE(errorMessage);
+    CHECK(string(errorMessage) == "encoder error: not writing a dictionary");
+    FLEncoder_Free(enc);
+}
+
+
 TEST_CASE("API Paths", "[API][Encoder]") {
     alloc_slice fleeceData = readTestFile(kBigJSONTestFileName);
     Doc doc = Doc::fromJSON(fleeceData);


### PR DESCRIPTION
Ensure you can still get the error message from an encoder after calling Finish on it.
Fixes #229