### PR TITLE
Fixed doxygen warnings

### DIFF
--- a/API/fleece/Expert.hh
+++ b/API/fleece/Expert.hh
@@ -30,7 +30,7 @@ namespace fleece {
     //  For documentation, see the comments above the C functions these wrap.
 
 
-    /** Just a simple wrapper around \ref FLValue_FromData.
+    /** Just a simple wrapper around `FLValue_FromData`.
         You should generally use a \ref Doc instead; it's safer.*/
     inline Value ValueFromData(slice data, FLTrust t =kFLUntrusted) {
         return FLValue_FromData(data,t);

--- a/API/fleece/FLExpert.h
+++ b/API/fleece/FLExpert.h
@@ -155,7 +155,7 @@ extern "C" {
     /** Reverts an FLSharedKeys by "forgetting" any keys added since it had the count `oldCount`. */
     FLEECE_PUBLIC void FLSharedKeys_RevertToCount(FLSharedKeys, unsigned oldCount) FLAPI;
 
-    /** Disable caching of the SharedKeys.. */
+    /** Disable caching of the SharedKeys. */
     FLEECE_PUBLIC void FLSharedKeys_DisableCaching(FLSharedKeys) FLAPI;
 
     /** Increments the reference count of an FLSharedKeys. */

--- a/API/fleece/FLJSON.h
+++ b/API/fleece/FLJSON.h
@@ -24,7 +24,8 @@ extern "C" {
 
     // This is the C API! For the C++ API, see Fleece.hh.
 
-    /** \defgroup json   JSON Interoperability */
+    /** \defgroup json   JSON Interoperability
+        @{ */
 
      /** \name Converting to JSON
         @{
@@ -75,7 +76,7 @@ extern "C" {
     FLEECE_PUBLIC bool FLEncoder_ConvertJSON(FLEncoder, FLSlice json) FLAPI;
 
     /** @} */
-
+    /** @} */
 
 #ifdef __cplusplus
 }

--- a/API/fleece/FLMutable.h
+++ b/API/fleece/FLMutable.h
@@ -513,7 +513,6 @@ extern "C" {
 
 
     /** @} */
-    /** @} */
 
 #ifdef __cplusplus
 }

--- a/Documentation/Doxyfile
+++ b/Documentation/Doxyfile
@@ -871,9 +871,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = API/fleece/FLSlice.h \
-                         API/fleece/Fleece.h \
-                         API/fleece/Fleece+CoreFoundation.h
+INPUT                  = API/fleece/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1252,15 +1250,6 @@ HTML_COLORSTYLE_SAT    = 180
 
 HTML_COLORSTYLE_GAMMA  = 80
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting this
-# to YES can help to show when doxygen was last run and thus if the
-# documentation is up to date.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-HTML_TIMESTAMP         = YES
-
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that
 # are dynamically created via JavaScript. If disabled, the navigation index will
@@ -1570,17 +1559,6 @@ HTML_FORMULA_FORMAT    = png
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 FORMULA_FONTSIZE       = 10
-
-# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
-# generated for formulas are transparent PNGs. Transparent PNGs are not
-# supported properly for IE 6.0, but are supported on all modern browsers.
-#
-# Note that when changing this option you need to delete any form_*.png files in
-# the HTML output directory before the changes have effect.
-# The default value is: YES.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-FORMULA_TRANSPARENT    = YES
 
 # The FORMULA_MACROFILE can contain LaTeX \newcommand and \renewcommand commands
 # to create new LaTeX commands to be used in formulas as building blocks. See
@@ -1918,14 +1896,6 @@ LATEX_HIDE_INDICES     = NO
 
 LATEX_BIB_STYLE        = plain
 
-# If the LATEX_TIMESTAMP tag is set to YES then the footer of each generated
-# page will contain the date and time when the page was generated. Setting this
-# to NO can help when comparing the output of multiple runs.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_TIMESTAMP        = NO
-
 # The LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute)
 # path from which the emoji images will be read. If a relative path is entered,
 # it will be relative to the LATEX_OUTPUT directory. If left blank the
@@ -2194,7 +2164,12 @@ INCLUDE_FILE_PATTERNS  =
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED             = DOXYGEN_PARSING=1 \
-                         NONNULL=
+                         FL_NONNULL= \
+                         FL_NULLABLE= \
+                         FL_PURE= \
+                         LIFETIMEBOUND= \
+                         NONNULL= \
+                         STEPOVER=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The
@@ -2265,15 +2240,6 @@ EXTERNAL_PAGES         = YES
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
 
-# If the CLASS_DIAGRAMS tag is set to YES, doxygen will generate a class diagram
-# (in HTML and LaTeX) for classes with base or super classes. Setting the tag to
-# NO turns the diagrams off. Note that this option also works with HAVE_DOT
-# disabled, but it is recommended to install and use dot, since it yields more
-# powerful graphs.
-# The default value is: YES.
-
-CLASS_DIAGRAMS         = YES
-
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The
 # DIA_PATH tag allows you to specify the directory where the dia binary resides.
@@ -2305,23 +2271,6 @@ HAVE_DOT               = NO
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_NUM_THREADS        = 0
-
-# When you want a differently looking font in the dot files that doxygen
-# generates you can specify the font name using DOT_FONTNAME. You need to make
-# sure dot is able to find the font, which can be done by putting it in a
-# standard location or by setting the DOTFONTPATH environment variable or by
-# setting DOT_FONTPATH to the directory containing the font.
-# The default value is: Helvetica.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_FONTNAME           = Helvetica
-
-# The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
-# dot graphs.
-# Minimum value: 4, maximum value: 24, default value: 10.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_FONTSIZE           = 10
 
 # By default doxygen will tell dot to use the default font as specified with
 # DOT_FONTNAME. If you specify a different font using DOT_FONTNAME you can set
@@ -2556,18 +2505,6 @@ DOT_GRAPH_MAX_NODES    = 50
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 MAX_DOT_GRAPH_DEPTH    = 0
-
-# Set the DOT_TRANSPARENT tag to YES to generate images with a transparent
-# background. This is disabled by default, because dot on Windows does not seem
-# to support this out of the box.
-#
-# Warning: Depending on the platform used, enabling this option may lead to
-# badly anti-aliased labels on the edges of a graph (i.e. they become hard to
-# read).
-# The default value is: NO.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_TRANSPARENT        = NO
 
 # Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
 # files in one run (i.e. multiple -o and -T options on the command line). This

--- a/Documentation/Doxyfile_C++
+++ b/Documentation/Doxyfile_C++
@@ -5,6 +5,5 @@
 PROJECT_NAME           = "Fleece (C++ API)"
 OUTPUT_DIRECTORY       = "Documentation/Cpp"
 OPTIMIZE_OUTPUT_FOR_C  = NO
-INPUT                  = API/fleece/
 FILE_PATTERNS          = *.hh
 BUILTIN_STL_SUPPORT    = YES

--- a/Fleece.xcodeproj/project.pbxproj
+++ b/Fleece.xcodeproj/project.pbxproj
@@ -1245,7 +1245,7 @@
 		270FA2541BF53CAD005DCB13 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1320;
+				LastUpgradeCheck = 1540;
 				ORGANIZATIONNAME = Couchbase;
 				TargetAttributes = {
 					270FA25B1BF53CAD005DCB13 = {
@@ -1302,6 +1302,8 @@
 				"$(SRCROOT)/API/fleece/Fleece.hh",
 				"$(SRCROOT)/API/fleece/Mutable.hh",
 				"$(SRCROOT)/API/fleece/Base.hh",
+				"$(SRCROOT)/Documentation/Doxyfile",
+				"$(SRCROOT)/Documentation/Doxyfile_C++",
 			);
 			name = "Build Documentation";
 			outputFileListPaths = (


### PR DESCRIPTION
- Removed obsolete properties from Doxyfile
- Removed a \ref in Expert.hh that doxygen couldn't identify because it's to a C function, and the Doxyfile_C++ doesn't include the C headers.
- Made Xcode run doxygen if either Doxyfile has been touched.
- Fixed Xcode 15 settings nags, while I was at it