### PR TITLE
Fixed Backtrace terminate handler not capturing any frames

### DIFF
--- a/Fleece/Support/Backtrace.cc
+++ b/Fleece/Support/Backtrace.cc
@@ -344,7 +344,7 @@ namespace fleece {
 
     Backtrace::Backtrace(unsigned skipFrames, unsigned maxFrames) {
         if (maxFrames > 0)
-            capture(skipFrames + 1, maxFrames);
+            _capture(skipFrames + 1, maxFrames);
     }
 
 

--- a/Fleece/Support/Backtrace.hh
+++ b/Fleece/Support/Backtrace.hh
@@ -25,7 +25,7 @@ namespace fleece {
     class Backtrace {
     public:
         /// Captures a backtrace and returns a shared pointer to the instance.
-        static std::shared_ptr<Backtrace> capture(unsigned skipFrames =0, unsigned maxFrames =50);
+        [[nodiscard]] static std::shared_ptr<Backtrace> capture(unsigned skipFrames =0, unsigned maxFrames =50);
 
         /// Captures a backtrace, unless maxFrames is zero.
         /// @param skipFrames  Number of frames to skip at top of stack

--- a/Fleece/Support/Backtrace.hh
+++ b/Fleece/Support/Backtrace.hh
@@ -71,11 +71,12 @@ namespace fleece {
 
     private:
         void _capture(unsigned skipFrames =0, unsigned maxFrames =50);
-        char* printFrame(unsigned i) const;
+        const char* getSymbol(unsigned i) const;
+        [[nodiscard]] char* printFrame(unsigned i) const;
         static void writeCrashLog(std::ostream&);
 
         std::vector<void*> _addrs;          // Array of PCs in backtrace, top first
-        char** _symbols { nullptr };
+        mutable char** _symbols { nullptr };
     };
 
 

--- a/Tests/SupportTests.cc
+++ b/Tests/SupportTests.cc
@@ -13,6 +13,7 @@
 #include "fleece/FLBase.h"
 #include "FleeceTests.hh"
 #include "FleeceImpl.hh"
+#include "Backtrace.hh"
 #include "ConcurrentMap.hh"
 #include "Bitmap.hh"
 #include "TempArray.hh"
@@ -343,4 +344,17 @@ TEST_CASE("Timestamp Conversions", "[Timestamps]") {
     FLStringResult str = FLTimestamp_ToString(ts, asUTC);
     FLTimestamp ts2 = FLTimestamp_FromString((FLString)str);
     CHECK(ts == ts2);
+}
+
+
+static Backtrace makeBacktrace() {
+    return Backtrace();
+}
+
+
+TEST_CASE("Backtrace") {
+    Backtrace bt = makeBacktrace();
+    string str = bt.toString();
+    cout << str << endl;
+    CHECK(std::count(str.begin(), str.end(), '\n') >= 4);
 }


### PR DESCRIPTION
There was a dumb typo, maybe mine, that prevented some uses of Backtrace from capturing any stack frames.
This explains why the terminate handler isn't logging a backtrace.