### PR TITLE
More compiler warnings, and sanitizers, in CMake builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,12 +45,12 @@ jobs:
     - name: Configure CMake
       if: runner.os != 'Windows'
       working-directory: ${{github.workspace}}/build
-      run: cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFLEECE_SANITIZE=ON
 
     - name: Configure CMake (Windows)
       if: runner.os == 'Windows'
       working-directory: ${{github.workspace}}/build
-      run: cmake .. -A x64
+      run: cmake .. -A x64 -DFLEECE_SANITIZE=ON
 
     - name: Build
       working-directory: ${{github.workspace}}/build

--- a/API/fleece/CompilerSupport.h
+++ b/API/fleece/CompilerSupport.h
@@ -245,6 +245,14 @@
 #endif
 
 
+// Suppresses sanitizers in a function
+#ifndef _MSC_VER
+#   define __no_sanitize(X)     __attribute__((no_sanitize(X)))
+#else
+#   define __no_sanitize(X)
+#endif
+
+
 #ifndef _MSC_VER
     #define WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) 0
 #endif

--- a/API/fleece/Expert.hh
+++ b/API/fleece/Expert.hh
@@ -32,7 +32,7 @@ namespace fleece {
 
     /** Just a simple wrapper around \ref FLValue_FromData.
         You should generally use a \ref Doc instead; it's safer.*/
-    static inline Value ValueFromData(slice data, FLTrust t =kFLUntrusted) {
+    inline Value ValueFromData(slice data, FLTrust t =kFLUntrusted) {
         return FLValue_FromData(data,t);
     }
 
@@ -47,7 +47,7 @@ namespace fleece {
         Encoder_ExpertAPI() = delete;
 
         /// Creates an Encoder that writes directly to a file.
-        static inline Encoder encodeToFile(FILE *file, bool uniqueStrings =true);
+        inline Encoder encodeToFile(FILE *file, bool uniqueStrings =true);
 
         inline void amend(slice base, bool reuseStrings =false, bool externPointers =false);
 
@@ -64,8 +64,8 @@ namespace fleece {
     };
 
     // use this to call one of the above methods; e.g. `expert(e).suppressTrailer()`.
-    static inline auto& expert(Encoder &enc)        {return (Encoder_ExpertAPI&)enc;}
-    static inline auto& expert(const Encoder &enc)  {return (const Encoder_ExpertAPI&)(enc);}
+    inline auto& expert(Encoder &enc)        {return (Encoder_ExpertAPI&)enc;}
+    inline auto& expert(const Encoder &enc)  {return (const Encoder_ExpertAPI&)(enc);}
 
 
     //====== DELTAS:

--- a/API/fleece/FLBase.h
+++ b/API/fleece/FLBase.h
@@ -72,7 +72,8 @@ extern "C" {
             storage.
             If invalid data is read by this call, subsequent calls to Value accessor functions can
             crash or return bogus results (including data from arbitrary memory locations.) */
-        kFLTrusted
+        kFLTrusted,
+        _kFLTrustInternalUseOnly = -1
     } FLTrust;
 
 

--- a/API/fleece/FLMutable.h
+++ b/API/fleece/FLMutable.h
@@ -64,11 +64,11 @@ extern "C" {
     NODISCARD FLEECE_PUBLIC FLMutableArray FL_NULLABLE FLMutableArray_New(void) FLAPI;
 
     /** Increments the ref-count of a mutable Array. */
-    static inline FLMutableArray FL_NULLABLE FLMutableArray_Retain(FLMutableArray FL_NULLABLE d) {
+    inline FLMutableArray FL_NULLABLE FLMutableArray_Retain(FLMutableArray FL_NULLABLE d) {
         return (FLMutableArray)FLValue_Retain((FLValue)d);
     }
     /** Decrements the refcount of (and possibly frees) a mutable Array. */
-    static inline void FLMutableArray_Release(FLMutableArray FL_NULLABLE d) {
+    inline void FLMutableArray_Release(FLMutableArray FL_NULLABLE d) {
         FLValue_Release((FLValue)d);
     }
 
@@ -122,54 +122,54 @@ extern "C" {
 
 
     /// Stores a JSON null value into an array.
-    static inline void FLMutableArray_SetNull(FLMutableArray, uint32_t index);
+    inline void FLMutableArray_SetNull(FLMutableArray, uint32_t index);
     /// Stores a boolean value into an array.
-    static inline void FLMutableArray_SetBool(FLMutableArray, uint32_t index, bool);
+    inline void FLMutableArray_SetBool(FLMutableArray, uint32_t index, bool);
     /// Stores an integer into an array.
-    static inline void FLMutableArray_SetInt(FLMutableArray, uint32_t index, int64_t);
+    inline void FLMutableArray_SetInt(FLMutableArray, uint32_t index, int64_t);
     /// Stores an unsigned integer into an array.
     /// \note: The only time this needs to be called, instead of \ref FLMutableArray_SetInt,
     ///        is if the value is greater than or equal to 2^63 and won't fit in an `int64_t`.
-    static inline void FLMutableArray_SetUInt(FLMutableArray, uint32_t index, uint64_t);
+    inline void FLMutableArray_SetUInt(FLMutableArray, uint32_t index, uint64_t);
     /// Stores a 32-bit floating-point number into an array.
-    static inline void FLMutableArray_SetFloat(FLMutableArray, uint32_t index, float);
+    inline void FLMutableArray_SetFloat(FLMutableArray, uint32_t index, float);
     /// Stores a 64-bit floating point number into an array.
-    static inline void FLMutableArray_SetDouble(FLMutableArray, uint32_t index, double);
+    inline void FLMutableArray_SetDouble(FLMutableArray, uint32_t index, double);
     /// Stores a UTF-8-encoded string into an array.
-    static inline void FLMutableArray_SetString(FLMutableArray, uint32_t index, FLString);
+    inline void FLMutableArray_SetString(FLMutableArray, uint32_t index, FLString);
     /// Stores a binary data blob into an array.
-    static inline void FLMutableArray_SetData(FLMutableArray, uint32_t index, FLSlice);
+    inline void FLMutableArray_SetData(FLMutableArray, uint32_t index, FLSlice);
     /// Stores a Fleece value into an array.
-    static inline void FLMutableArray_SetValue(FLMutableArray, uint32_t index, FLValue);
+    inline void FLMutableArray_SetValue(FLMutableArray, uint32_t index, FLValue);
     /// Stores a Fleece array into an array
-    static inline void FLMutableArray_SetArray(FLMutableArray, uint32_t index, FLArray);
+    inline void FLMutableArray_SetArray(FLMutableArray, uint32_t index, FLArray);
     /// Stores a Fleece dictionary into an array
-    static inline void FLMutableArray_SetDict(FLMutableArray, uint32_t index, FLDict);
+    inline void FLMutableArray_SetDict(FLMutableArray, uint32_t index, FLDict);
 
     /// Appends a JSON null value to an array.
-    static inline void FLMutableArray_AppendNull(FLMutableArray);
+    inline void FLMutableArray_AppendNull(FLMutableArray);
     /// Appends a boolean value to an array.
-    static inline void FLMutableArray_AppendBool(FLMutableArray, bool);
+    inline void FLMutableArray_AppendBool(FLMutableArray, bool);
     /// Appends an integer to an array.
-    static inline void FLMutableArray_AppendInt(FLMutableArray, int64_t);
+    inline void FLMutableArray_AppendInt(FLMutableArray, int64_t);
     /// Appends an unsigned integer to an array.
     /// \note: The only time this needs to be called, instead of \ref FLMutableArray_AppendInt,
     ///        is if the value is greater than or equal to 2^63 and won't fit in an `int64_t`.
-    static inline void FLMutableArray_AppendUInt(FLMutableArray, uint64_t);
+    inline void FLMutableArray_AppendUInt(FLMutableArray, uint64_t);
     /// Appends a 32-bit floating-point number to an array.
-    static inline void FLMutableArray_AppendFloat(FLMutableArray, float);
+    inline void FLMutableArray_AppendFloat(FLMutableArray, float);
     /// Appends a 64-bit floating point number to an array.
-    static inline void FLMutableArray_AppendDouble(FLMutableArray, double);
+    inline void FLMutableArray_AppendDouble(FLMutableArray, double);
     /// Appends a UTF-8-encoded string to an array.
-    static inline void FLMutableArray_AppendString(FLMutableArray, FLString);
+    inline void FLMutableArray_AppendString(FLMutableArray, FLString);
     /// Appends a binary data blob to an array.
-    static inline void FLMutableArray_AppendData(FLMutableArray, FLSlice);
+    inline void FLMutableArray_AppendData(FLMutableArray, FLSlice);
     /// Appends a Fleece value to an array.
-    static inline void FLMutableArray_AppendValue(FLMutableArray, FLValue);
+    inline void FLMutableArray_AppendValue(FLMutableArray, FLValue);
     /// Appends a Fleece array to an array
-    static inline void FLMutableArray_AppendArray(FLMutableArray, FLArray);
+    inline void FLMutableArray_AppendArray(FLMutableArray, FLArray);
     /// Appends a Fleece dictionary to an array
-    static inline void FLMutableArray_AppendDict(FLMutableArray, FLDict);
+    inline void FLMutableArray_AppendDict(FLMutableArray, FLDict);
 
     /** @} */
 
@@ -197,12 +197,12 @@ extern "C" {
     FLEECE_PUBLIC FLMutableDict FL_NULLABLE FLMutableDict_New(void) FLAPI;
 
     /** Increments the ref-count of a mutable Dict. */
-    static inline FLMutableDict FL_NULLABLE FLMutableDict_Retain(FLMutableDict FL_NULLABLE d) {
+    inline FLMutableDict FL_NULLABLE FLMutableDict_Retain(FLMutableDict FL_NULLABLE d) {
         return (FLMutableDict)FLValue_Retain((FLValue)d);
     }
 
     /** Decrements the refcount of (and possibly frees) a mutable Dict. */
-    static inline void FLMutableDict_Release(FLMutableDict FL_NULLABLE d) {
+    inline void FLMutableDict_Release(FLMutableDict FL_NULLABLE d) {
         FLValue_Release((FLValue)d);
     }
 
@@ -237,29 +237,29 @@ extern "C" {
 
 
     /// Stores a JSON null value into a mutable dictionary.
-    static inline void FLMutableDict_SetNull(FLMutableDict, FLString key);
+    inline void FLMutableDict_SetNull(FLMutableDict, FLString key);
     /// Stores a boolean value into a mutable dictionary.
-    static inline void FLMutableDict_SetBool(FLMutableDict, FLString key, bool);
+    inline void FLMutableDict_SetBool(FLMutableDict, FLString key, bool);
     /// Stores an integer into a mutable dictionary.
-    static inline void FLMutableDict_SetInt(FLMutableDict, FLString key, int64_t);
+    inline void FLMutableDict_SetInt(FLMutableDict, FLString key, int64_t);
     /// Stores an unsigned integer into a mutable dictionary.
     /// \note: The only time this needs to be called, instead of \ref FLMutableDict_SetInt,
     ///        is if the value is greater than or equal to 2^63 and won't fit in an `int64_t`.
-    static inline void FLMutableDict_SetUInt(FLMutableDict, FLString key, uint64_t);
+    inline void FLMutableDict_SetUInt(FLMutableDict, FLString key, uint64_t);
     /// Stores a 32-bit floating-point number into a mutable dictionary.
-    static inline void FLMutableDict_SetFloat(FLMutableDict, FLString key, float);
+    inline void FLMutableDict_SetFloat(FLMutableDict, FLString key, float);
     /// Stores a 64-bit floating point number into a mutable dictionary.
-    static inline void FLMutableDict_SetDouble(FLMutableDict, FLString key, double);
+    inline void FLMutableDict_SetDouble(FLMutableDict, FLString key, double);
     /// Stores a UTF-8-encoded string into a mutable dictionary.
-    static inline void FLMutableDict_SetString(FLMutableDict, FLString key, FLString);
+    inline void FLMutableDict_SetString(FLMutableDict, FLString key, FLString);
     /// Stores a binary data blob into a mutable dictionary.
-    static inline void FLMutableDict_SetData(FLMutableDict, FLString key, FLSlice);
+    inline void FLMutableDict_SetData(FLMutableDict, FLString key, FLSlice);
     /// Stores a Fleece value into a mutable dictionary.
-    static inline void FLMutableDict_SetValue(FLMutableDict, FLString key, FLValue);
+    inline void FLMutableDict_SetValue(FLMutableDict, FLString key, FLValue);
     /// Stores a Fleece array into a mutable dictionary.
-    static inline void FLMutableDict_SetArray(FLMutableDict, FLString key, FLArray);
+    inline void FLMutableDict_SetArray(FLMutableDict, FLString key, FLArray);
     /// Stores a Fleece dictionary into a mutable dictionary.
-    static inline void FLMutableDict_SetDict(FLMutableDict, FLString key, FLDict);
+    inline void FLMutableDict_SetDict(FLMutableDict, FLString key, FLDict);
 
     /** @} */
 
@@ -332,11 +332,11 @@ extern "C" {
     FLEECE_PUBLIC void FLSlot_SetData(FLSlot, FLSlice) FLAPI;    ///< Stores a data blob into a slot.
     FLEECE_PUBLIC void FLSlot_SetValue(FLSlot, FLValue) FLAPI;   ///< Stores an FLValue into a slot.
 
-    static inline void FLSlot_SetArray(FLSlot slot, FLArray array) {
+    inline void FLSlot_SetArray(FLSlot slot, FLArray array) {
         FLSlot_SetValue(slot, (FLValue)array);
     }
 
-    static inline void FLSlot_SetDict(FLSlot slot, FLDict dict) {
+    inline void FLSlot_SetDict(FLSlot slot, FLDict dict) {
         FLSlot_SetValue(slot, (FLValue)dict);
     }
 
@@ -409,105 +409,105 @@ extern "C" {
 
     // implementations of the inline methods declared earlier:
 
-    static inline void FLMutableArray_SetNull(FLMutableArray a, uint32_t index) {
+    inline void FLMutableArray_SetNull(FLMutableArray a, uint32_t index) {
         FLSlot_SetNull(FLMutableArray_Set(a, index));
     }
-    static inline void FLMutableArray_SetBool(FLMutableArray a, uint32_t index, bool val) {
+    inline void FLMutableArray_SetBool(FLMutableArray a, uint32_t index, bool val) {
         FLSlot_SetBool(FLMutableArray_Set(a, index), val);
     }
-    static inline void FLMutableArray_SetInt(FLMutableArray a, uint32_t index, int64_t val) {
+    inline void FLMutableArray_SetInt(FLMutableArray a, uint32_t index, int64_t val) {
         FLSlot_SetInt(FLMutableArray_Set(a, index), val);
     }
-    static inline void FLMutableArray_SetUInt(FLMutableArray a, uint32_t index, uint64_t val) {
+    inline void FLMutableArray_SetUInt(FLMutableArray a, uint32_t index, uint64_t val) {
         FLSlot_SetUInt(FLMutableArray_Set(a, index), val);
     }
-    static inline void FLMutableArray_SetFloat(FLMutableArray a, uint32_t index, float val) {
+    inline void FLMutableArray_SetFloat(FLMutableArray a, uint32_t index, float val) {
         FLSlot_SetFloat(FLMutableArray_Set(a, index), val);
     }
-    static inline void FLMutableArray_SetDouble(FLMutableArray a, uint32_t index, double val) {
+    inline void FLMutableArray_SetDouble(FLMutableArray a, uint32_t index, double val) {
         FLSlot_SetDouble(FLMutableArray_Set(a, index), val);
     }
-    static inline void FLMutableArray_SetString(FLMutableArray a, uint32_t index, FLString val) {
+    inline void FLMutableArray_SetString(FLMutableArray a, uint32_t index, FLString val) {
         FLSlot_SetString(FLMutableArray_Set(a, index), val);
     }
-    static inline void FLMutableArray_SetData(FLMutableArray a, uint32_t index, FLSlice val) {
+    inline void FLMutableArray_SetData(FLMutableArray a, uint32_t index, FLSlice val) {
         FLSlot_SetData(FLMutableArray_Set(a, index), val);
     }
-    static inline void FLMutableArray_SetValue(FLMutableArray a, uint32_t index, FLValue val) {
+    inline void FLMutableArray_SetValue(FLMutableArray a, uint32_t index, FLValue val) {
         FLSlot_SetValue(FLMutableArray_Set(a, index), val);
     }
-    static inline void FLMutableArray_SetArray(FLMutableArray a, uint32_t index, FLArray val) {
+    inline void FLMutableArray_SetArray(FLMutableArray a, uint32_t index, FLArray val) {
         FLSlot_SetValue(FLMutableArray_Set(a, index), (FLValue)val);
     }
-    static inline void FLMutableArray_SetDict(FLMutableArray a, uint32_t index, FLDict val) {
+    inline void FLMutableArray_SetDict(FLMutableArray a, uint32_t index, FLDict val) {
         FLSlot_SetValue(FLMutableArray_Set(a, index), (FLValue)val);
     }
 
-    static inline void FLMutableArray_AppendNull(FLMutableArray a) {
+    inline void FLMutableArray_AppendNull(FLMutableArray a) {
         FLSlot_SetNull(FLMutableArray_Append(a));
     }
-    static inline void FLMutableArray_AppendBool(FLMutableArray a, bool val) {
+    inline void FLMutableArray_AppendBool(FLMutableArray a, bool val) {
         FLSlot_SetBool(FLMutableArray_Append(a), val);
     }
-    static inline void FLMutableArray_AppendInt(FLMutableArray a, int64_t val) {
+    inline void FLMutableArray_AppendInt(FLMutableArray a, int64_t val) {
         FLSlot_SetInt(FLMutableArray_Append(a), val);
     }
-    static inline void FLMutableArray_AppendUInt(FLMutableArray a, uint64_t val) {
+    inline void FLMutableArray_AppendUInt(FLMutableArray a, uint64_t val) {
         FLSlot_SetUInt(FLMutableArray_Append(a), val);
     }
-    static inline void FLMutableArray_AppendFloat(FLMutableArray a, float val) {
+    inline void FLMutableArray_AppendFloat(FLMutableArray a, float val) {
         FLSlot_SetFloat(FLMutableArray_Append(a), val);
     }
-    static inline void FLMutableArray_AppendDouble(FLMutableArray a, double val) {
+    inline void FLMutableArray_AppendDouble(FLMutableArray a, double val) {
         FLSlot_SetDouble(FLMutableArray_Append(a), val);
     }
-    static inline void FLMutableArray_AppendString(FLMutableArray a, FLString val) {
+    inline void FLMutableArray_AppendString(FLMutableArray a, FLString val) {
         FLSlot_SetString(FLMutableArray_Append(a), val);
     }
-    static inline void FLMutableArray_AppendData(FLMutableArray a, FLSlice val) {
+    inline void FLMutableArray_AppendData(FLMutableArray a, FLSlice val) {
         FLSlot_SetData(FLMutableArray_Append(a), val);
     }
-    static inline void FLMutableArray_AppendValue(FLMutableArray a, FLValue val) {
+    inline void FLMutableArray_AppendValue(FLMutableArray a, FLValue val) {
         FLSlot_SetValue(FLMutableArray_Append(a), val);
     }
-    static inline void FLMutableArray_AppendArray(FLMutableArray a, FLArray val) {
+    inline void FLMutableArray_AppendArray(FLMutableArray a, FLArray val) {
         FLSlot_SetValue(FLMutableArray_Append(a), (FLValue)val);
     }
-    static inline void FLMutableArray_AppendDict(FLMutableArray a, FLDict val) {
+    inline void FLMutableArray_AppendDict(FLMutableArray a, FLDict val) {
         FLSlot_SetValue(FLMutableArray_Append(a), (FLValue)val);
     }
 
-    static inline void FLMutableDict_SetNull(FLMutableDict d, FLString key) {
+    inline void FLMutableDict_SetNull(FLMutableDict d, FLString key) {
         FLSlot_SetNull(FLMutableDict_Set(d, key));
     }
-    static inline void FLMutableDict_SetBool(FLMutableDict d, FLString key, bool val) {
+    inline void FLMutableDict_SetBool(FLMutableDict d, FLString key, bool val) {
         FLSlot_SetBool(FLMutableDict_Set(d, key), val);
     }
-    static inline void FLMutableDict_SetInt(FLMutableDict d, FLString key, int64_t val) {
+    inline void FLMutableDict_SetInt(FLMutableDict d, FLString key, int64_t val) {
         FLSlot_SetInt(FLMutableDict_Set(d, key), val);
     }
-    static inline void FLMutableDict_SetUInt(FLMutableDict d, FLString key, uint64_t val) {
+    inline void FLMutableDict_SetUInt(FLMutableDict d, FLString key, uint64_t val) {
         FLSlot_SetUInt(FLMutableDict_Set(d, key), val);
     }
-    static inline void FLMutableDict_SetFloat(FLMutableDict d, FLString key, float val) {
+    inline void FLMutableDict_SetFloat(FLMutableDict d, FLString key, float val) {
         FLSlot_SetFloat(FLMutableDict_Set(d, key), val);
     }
-    static inline void FLMutableDict_SetDouble(FLMutableDict d, FLString key, double val) {
+    inline void FLMutableDict_SetDouble(FLMutableDict d, FLString key, double val) {
         FLSlot_SetDouble(FLMutableDict_Set(d, key), val);
     }
-    static inline void FLMutableDict_SetString(FLMutableDict d, FLString key, FLString val) {
+    inline void FLMutableDict_SetString(FLMutableDict d, FLString key, FLString val) {
         FLSlot_SetString(FLMutableDict_Set(d, key), val);
     }
-    static inline void FLMutableDict_SetData(FLMutableDict d, FLString key, FLSlice val) {
+    inline void FLMutableDict_SetData(FLMutableDict d, FLString key, FLSlice val) {
         FLSlot_SetData(FLMutableDict_Set(d, key), val);
     }
-    static inline void FLMutableDict_SetValue(FLMutableDict d, FLString key, FLValue val) {
+    inline void FLMutableDict_SetValue(FLMutableDict d, FLString key, FLValue val) {
         FLSlot_SetValue(FLMutableDict_Set(d, key), val);
     }
-    static inline void FLMutableDict_SetArray(FLMutableDict d, FLString key, FLArray val) {
+    inline void FLMutableDict_SetArray(FLMutableDict d, FLString key, FLArray val) {
         FLSlot_SetValue(FLMutableDict_Set(d, key), (FLValue)val);
     }
-    static inline void FLMutableDict_SetDict(FLMutableDict d, FLString key, FLDict val) {
+    inline void FLMutableDict_SetDict(FLMutableDict d, FLString key, FLDict val) {
         FLSlot_SetValue(FLMutableDict_Set(d, key), (FLValue)val);
     }
 

--- a/API/fleece/FLSlice.h
+++ b/API/fleece/FLSlice.h
@@ -103,7 +103,7 @@ typedef FLSliceResult FLStringResult;
 
 /** Exactly like memcmp, but safely handles the case where a or b is NULL and size is 0 (by returning 0),
     instead of producing "undefined behavior" as per the C spec. */
-static inline FLPURE int FLMemCmp(const void * FL_NULLABLE a,
+inline FLPURE int FLMemCmp(const void * FL_NULLABLE a,
                                   const void * FL_NULLABLE b, size_t size) FLAPI
 {
     if (_usuallyFalse(size == 0))
@@ -113,7 +113,7 @@ static inline FLPURE int FLMemCmp(const void * FL_NULLABLE a,
 
 /** Exactly like memcmp, but safely handles the case where dst or src is NULL and size is 0 (as a no-op),
     instead of producing "undefined behavior" as per the C spec. */
-static inline void FLMemCpy(void* FL_NULLABLE dst, const void* FL_NULLABLE src, size_t size) FLAPI {
+inline void FLMemCpy(void* FL_NULLABLE dst, const void* FL_NULLABLE src, size_t size) FLAPI {
     if (_usuallyTrue(size > 0))
         memcpy(dst, src, size);
 }
@@ -123,7 +123,7 @@ static inline void FLMemCpy(void* FL_NULLABLE dst, const void* FL_NULLABLE src, 
     It's OK to pass NULL; this returns an empty slice.
     \note If the string is a literal, it's more efficient to use \ref FLSTR instead.
     \note Performance is O(n) with the length of the string, since it has to call `strlen`. */
-static inline FLSlice FLStr(const char* FL_NULLABLE str) FLAPI {
+inline FLSlice FLStr(const char* FL_NULLABLE str) FLAPI {
     FLSlice foo = { str, str ? strlen(str) : 0 };
     return foo;
 }
@@ -164,7 +164,7 @@ FLEECE_PUBLIC FLSliceResult FLSlice_Copy(FLSlice) FLAPI;
 
 
 /** Allocates an FLSliceResult, copying `size` bytes starting at `buf`. */
-static inline FLSliceResult FLSliceResult_CreateWith(const void* FL_NULLABLE bytes, size_t size) FLAPI {
+inline FLSliceResult FLSliceResult_CreateWith(const void* FL_NULLABLE bytes, size_t size) FLAPI {
     FLSlice s = {bytes, size};
     return FLSlice_Copy(s);
 }
@@ -174,18 +174,18 @@ FLEECE_PUBLIC void _FLBuf_Retain(const void* FL_NULLABLE) FLAPI;   // internal; 
 FLEECE_PUBLIC void _FLBuf_Release(const void* FL_NULLABLE) FLAPI;  // internal; do not call
 
 /** Increments the ref-count of a FLSliceResult. */
-static inline FLSliceResult FLSliceResult_Retain(FLSliceResult s) FLAPI {
+inline FLSliceResult FLSliceResult_Retain(FLSliceResult s) FLAPI {
     _FLBuf_Retain(s.buf);
     return s;
 }
 
 /** Decrements the ref-count of a FLSliceResult, freeing its memory if it reached zero. */
-static inline void FLSliceResult_Release(FLSliceResult s) FLAPI {
+inline void FLSliceResult_Release(FLSliceResult s) FLAPI {
     _FLBuf_Release(s.buf);
 }
 
 /** Type-casts a FLSliceResult to FLSlice, since C doesn't know it's a subclass. */
-static inline FLSlice FLSliceResult_AsSlice(FLSliceResult sr) {
+inline FLSlice FLSliceResult_AsSlice(FLSliceResult sr) {
     FLSlice ret;
     memcpy(&ret, &sr, sizeof(ret));
     return ret;
@@ -203,11 +203,11 @@ FLEECE_PUBLIC void FL_WipeMemory(void *dst, size_t size) FLAPI;
 #ifdef __cplusplus
 }
 
-    FLPURE static inline bool operator== (FLSlice s1, FLSlice s2) {return FLSlice_Equal(s1, s2);}
-    FLPURE static inline bool operator!= (FLSlice s1, FLSlice s2) {return !(s1 == s2);}
+    FLPURE inline bool operator== (FLSlice s1, FLSlice s2) {return FLSlice_Equal(s1, s2);}
+    FLPURE inline bool operator!= (FLSlice s1, FLSlice s2) {return !(s1 == s2);}
 
-    FLPURE static inline bool operator== (FLSliceResult sr, FLSlice s) {return (FLSlice)sr == s;}
-    FLPURE static inline bool operator!= (FLSliceResult sr, FLSlice s) {return !(sr ==s);}
+    FLPURE inline bool operator== (FLSliceResult sr, FLSlice s) {return (FLSlice)sr == s;}
+    FLPURE inline bool operator!= (FLSliceResult sr, FLSlice s) {return !(sr ==s);}
 
 
     FLSliceResult::operator std::string () const {

--- a/API/fleece/FLValue.h
+++ b/API/fleece/FLValue.h
@@ -167,10 +167,10 @@ extern "C" {
         @warning It is illegal to call this on a value obtained from \ref FLValue_FromData. */
     FLEECE_PUBLIC void FLValue_Release(FLValue FL_NULLABLE) FLAPI;
 
-    static inline FLArray FL_NULLABLE FLArray_Retain(FLArray FL_NULLABLE v) {FLValue_Retain((FLValue)v); return v;}
-    static inline void FLArray_Release(FLArray FL_NULLABLE v)   {FLValue_Release((FLValue)v);}
-    static inline FLDict FL_NULLABLE FLDict_Retain(FLDict FL_NULLABLE v)    {FLValue_Retain((FLValue)v); return v;}
-    static inline void FLDict_Release(FLDict FL_NULLABLE v)     {FLValue_Release((FLValue)v);}
+    inline FLArray FL_NULLABLE FLArray_Retain(FLArray FL_NULLABLE v) {FLValue_Retain((FLValue)v); return v;}
+    inline void FLArray_Release(FLArray FL_NULLABLE v)   {FLValue_Release((FLValue)v);}
+    inline FLDict FL_NULLABLE FLDict_Retain(FLDict FL_NULLABLE v)    {FLValue_Retain((FLValue)v); return v;}
+    inline void FLDict_Release(FLDict FL_NULLABLE v)     {FLValue_Release((FLValue)v);}
 
     /** @} */
 

--- a/API/fleece/InstanceCounted.hh
+++ b/API/fleece/InstanceCounted.hh
@@ -11,6 +11,7 @@
 //
 
 #pragma once
+#include "fleece/CompilerSupport.h"
 #include "fleece/function_ref.hh"
 #include <cstddef> //for size_t
 #include <atomic>
@@ -77,19 +78,26 @@ namespace fleece {
     class InstanceCountedIn : public InstanceCounted {
     public:
 #if INSTANCECOUNTED_TRACK
+        __no_sanitize("undefined")
         InstanceCountedIn()
-        :InstanceCounted((size_t)this - (size_t)(BASE*)this)
+        :InstanceCounted(myOffset())
         { }
 
+        __no_sanitize("undefined")
         InstanceCountedIn(const InstanceCountedIn&)
-        :InstanceCounted((size_t)this - (size_t)(BASE*)this)
+        :InstanceCounted(myOffset())
         { }
 
+        __no_sanitize("undefined")
         InstanceCountedIn(InstanceCountedIn &&old)
-        :InstanceCounted((size_t)this - (size_t)(BASE*)this)
+        :InstanceCounted(myOffset())
         {
             old.untrack();
         }
+
+    private:
+        __no_sanitize("undefined")
+        size_t myOffset() {return (size_t)this - (size_t)static_cast<BASE*>(this);}
 #endif
     };
 

--- a/API/fleece/PlatformCompat.hh
+++ b/API/fleece/PlatformCompat.hh
@@ -21,8 +21,6 @@
     #define NOINLINE                        __declspec(noinline)
     #define ALWAYS_INLINE                   inline
     #define ASSUME(cond)                    __assume(cond)
-	#define LITECORE_UNUSED
-    #define __typeof                        decltype
 
     #define __func__                        __FUNCTION__
 
@@ -37,11 +35,6 @@
     #include <winapifamily.h>
 
 #else
-
-    // Suppresses "unused function" warnings
-    #if __has_attribute(unused)
-    #  define LITECORE_UNUSED __attribute__((unused))
-    #endif
 
     // Disables inlining a function. Use when the space savings are worth more than speed.
     #if __has_attribute(noinline)

--- a/API/fleece/RefCounted.hh
+++ b/API/fleece/RefCounted.hh
@@ -84,7 +84,7 @@ namespace fleece {
 
     // Makes `assignRef` polymorphic with RefCounted subclasses.
     template <typename T>
-    static inline void assignRef(T* &holder, RefCounted *newValue) noexcept {
+    inline void assignRef(T* &holder, RefCounted *newValue) noexcept {
         assignRef((RefCounted*&)holder, newValue);
     }
 
@@ -264,7 +264,7 @@ namespace fleece {
     /** make_retained<T>(...) is equivalent to `std::make_unique` and `std::make_shared`.
         It constructs a new RefCounted object, passing params to the constructor, returning a `Retained`. */
     template<class T, class... _Args>
-    [[nodiscard]] static inline Retained<T>
+    [[nodiscard]] inline Retained<T>
     make_retained(_Args&&... __args) {
         return Retained<T>(new T(std::forward<_Args>(__args)...));
     }

--- a/API/fleece/slice.hh
+++ b/API/fleece/slice.hh
@@ -338,7 +338,7 @@ namespace fleece {
 
 
     /** Literal syntax for slices: `"foo"_sl` */
-    inline constexpr slice operator "" _sl (const char *str, size_t length) noexcept {
+    inline constexpr slice operator ""_sl (const char *str, size_t length) noexcept {
         return slice(str, length);
     }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS
     $<$<CONFIG:Debug>:DEBUG>
 )
 
+option(FLEECE_WARNINGS_HARDCORE "Enables tons of warnings and makes them errors (Clang only)" OFF)
+option(FLEECE_SANITIZE "Enables address and undefined-behavior sanitizers (Clang only)" OFF)
+
 if(MSVC)
     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/platform_win.cmake")
 elseif(APPLE)
@@ -23,11 +26,84 @@ else()
     message(FATAL_ERROR "Unsupported platform ${CMAKE_SYSTEM_NAME}!")
 endif()
 
+set(FLEECE_CXX_WARNINGS "")
+if(FLEECE_WARNINGS_HARDCORE)
+    if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
+        set(FLEECE_CXX_WARNINGS
+            -Werror
+            -Weverything            # "WARN ALL THE THINGS!!!"
+            -Wformat=2
+            # Disabled C++ warnings:
+            -Wno-nullable-to-nonnull-conversion # TODO: "implicit conversion from nullable pointer to non-nullable pointer type"
+            -Wno-sign-compare # TODO "comparison of integers of different signs"
+            -Wno-undefined-func-template # TODO: Can't figure out how to fix MValue.hh
+            -Wno-alloca
+            -Wno-atomic-implicit-seq-cst # "implicit use of sequentially-consistent atomic may incur stronger memory barriers than necessary"
+            -Wno-c++98-compat
+            -Wno-c++98-compat-pedantic
+            -Wno-c99-extensions
+            -Wno-cast-align # "cast from X* to Y* increases required alignment"
+            -Wno-cast-qual  # "cast drops const qualifier"
+            -Wno-covered-switch-default # "default label in switch which covers all enumeration values"
+            -Wno-ctad-maybe-unsupported # "X may not intend to support class template argument deduction"
+            -Wno-custom-atomic-properties # "[Obj-C] atomic by default property 'X' has a user defined getter"
+            -Wno-date-time # "expansion of date or time macro is not reproducible"
+            -Wno-direct-ivar-access # "[Obj-C] instance variable '_x' is being directly accessed"
+            -Wno-double-promotion # "implicit conversion increases floating-point precision: 'float' to 'double'"
+            -Wno-exit-time-destructors # "declaration requires an exit-time destructor"
+            -Wno-float-equal
+            -Wno-format-pedantic # "format specifies type 'void *' but the argument has type 'C4Document *'"
+            -Wno-global-constructors
+            -Wno-gnu-anonymous-struct # "anonymous structs are a GNU extension"
+            -Wno-gnu-zero-variadic-macro-arguments # "token pasting of ',' and __VA_ARGS__ is a GNU extension"
+            -Wno-missing-field-initializers # "missing field 'x' initializer"
+            -Wno-nested-anon-types # "anonymous types declared in an anonymous union are an extension"
+            -Wno-nullability-extension
+            -Wno-objc-messaging-id
+            -Wno-old-style-cast
+            -Wno-padded # "padding size of X with N bytes to alignment boundary"
+            -Wno-sign-conversion
+            -Wno-suggest-destructor-override # "'~Foo' overrides a destructor but is not marked 'override'"
+            -Wno-super-class-method-mismatch # Obj-C "method parameter type does not match super class method parameter type"
+            -Wno-switch-enum
+            -Wno-undef      # `#if X` where X isn't defined
+            -Wno-unused-macros
+            -Wno-unused-parameter # Unused fn parameter
+            -Wno-weak-vtables # "Class has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit"
+        )
+    endif()
+endif()
+
+
+if (LITECORE_SANITIZE AND NOT CODE_COVERAGE_ENABLED AND (CMAKE_CXX_COMPILER_ID MATCHES Clang))
+    set(FLEECE_COMPILE_OPTIONS
+            -fstack-protector
+            -fsanitize=address
+            -fsanitize-address-use-after-return=always
+            -fsanitize-address-use-after-scope
+            -fsanitize=undefined
+            -fsanitize=nullability
+            -fno-sanitize-recover=all   # Always exit after UBSan warning
+            # Note: _FORTIFY_SOURCE is incompatible with ASan; defining it will cause build errors
+    )
+    set(FLEECE_LINK_OPTIONS
+        -fsanitize=address
+        -fsanitize=undefined
+    )
+else()
+    set(FLEECE_COMPILE_OPTIONS
+        -fstack-protector
+        -D_FORTIFY_SOURCE=2
+    )
+    set(FLEECE_LINK_OPTIONS "")
+endif()
+
 set_source_files(RESULT FLEECE_SRC)
 add_library(FleeceObjects OBJECT ${FLEECE_SRC})
 add_library(Fleece        SHARED  $<TARGET_OBJECTS:FleeceObjects>)
 add_library(FleeceStatic  STATIC  $<TARGET_OBJECTS:FleeceObjects>)
 target_compile_definitions(FleeceObjects PRIVATE FLEECE_EXPORTS)
+target_link_options(Fleece PRIVATE ${FLEECE_LINK_OPTIONS})
 
 # "FleeceBase" static lib for clients that just need support stuff like slice, varint, RefCounted...
 set_base_platform_files(RESULT FLEECE_BASE_PLATFORM_SRC)
@@ -53,6 +129,7 @@ add_library(FleeceBase    STATIC  ${FLEECE_BASE_SRC})
 # Command-Line Tool
 add_executable(fleeceTool Tool/fleece_tool.cc)
 target_link_libraries(fleeceTool FleeceObjects)
+target_link_options(fleeceTool PRIVATE ${FLEECE_LINK_OPTIONS})
 
 # Fleece Tests
 set_test_source_files(RESULT FLEECE_TEST_SRC)
@@ -63,6 +140,7 @@ target_link_libraries(FleeceTests FleeceObjects)
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     target_link_libraries(FleeceTests  "pthread")
 endif()
+target_link_options(FleeceTests PRIVATE ${FLEECE_LINK_OPTIONS})
 
 file(COPY Tests/1000people.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/Tests)
 file(COPY Tests/1person.fleece DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/Tests)
@@ -82,6 +160,12 @@ foreach(platform FleeceObjects Fleece FleeceStatic FleeceBase fleeceTool FleeceT
         vendor/libb64
         vendor/SwiftDtoa
         vendor/wyhash
+    )
+
+    target_compile_options(
+        ${platform} PRIVATE
+        ${FLEECE_COMPILE_OPTIONS}
+        $<$<COMPILE_LANGUAGE:CXX>:${FLEECE_CXX_WARNINGS}>
     )
 
     target_compile_definitions(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,6 @@ foreach(platform FleeceObjects Fleece FleeceStatic FleeceBase fleeceTool FleeceT
         Fleece/Integration
         Fleece/Mutable
         Fleece/Support
-        Fleece/Tree
-        Experimental
         vendor/date/include
         vendor/jsonsl
         vendor/libb64

--- a/Fleece.xcodeproj/project.pbxproj
+++ b/Fleece.xcodeproj/project.pbxproj
@@ -73,12 +73,8 @@
 		2779BA1124CB4A4900BCEA8F /* ConcurrentMap.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2779BA0F24CB4A4900BCEA8F /* ConcurrentMap.cc */; };
 		277A06B320B36D1A00970354 /* FileUtils.cc in Sources */ = {isa = PBXBuildFile; fileRef = 277A06B120B36D1A00970354 /* FileUtils.cc */; };
 		277A06B420B36D1A00970354 /* FileUtils.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277A06B220B36D1A00970354 /* FileUtils.hh */; };
-		277F45B0208E871000A0D159 /* HashTree.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277F45AE208E871000A0D159 /* HashTree.hh */; };
-		277F45B1208E871000A0D159 /* HashTree.cc in Sources */ = {isa = PBXBuildFile; fileRef = 277F45AF208E871000A0D159 /* HashTree.cc */; };
-		277F45B4208FDA1800A0D159 /* HashTreeTests.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27C8DF09208521B600A99BFC /* HashTreeTests.cc */; };
 		278163B51CE69CA800B94E32 /* Fleece.cc in Sources */ = {isa = PBXBuildFile; fileRef = 278163B31CE69CA800B94E32 /* Fleece.cc */; settings = {COMPILER_FLAGS = "-Wno-return-type-c-linkage"; }; };
 		278163B91CE6BB8C00B94E32 /* C_Test.c in Sources */ = {isa = PBXBuildFile; fileRef = 278163B81CE6BB8C00B94E32 /* C_Test.c */; };
-		278163BD1CE7A72300B94E32 /* KeyTree.hh in Headers */ = {isa = PBXBuildFile; fileRef = 278163BB1CE7A72300B94E32 /* KeyTree.hh */; };
 		278343132A675A7000621050 /* function_ref.hh in Headers */ = {isa = PBXBuildFile; fileRef = 278343122A675A7000621050 /* function_ref.hh */; };
 		27867AF2211E27E5007BDA5F /* Doc.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27867AF0211E27E5007BDA5F /* Doc.cc */; };
 		27867AF3211E27E5007BDA5F /* Doc.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27867AF1211E27E5007BDA5F /* Doc.hh */; };
@@ -97,8 +93,6 @@
 		27AEFAC321090FF400106ED8 /* JSONDelta.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27AEFAC121090FF400106ED8 /* JSONDelta.hh */; };
 		27AEFAC5210913C500106ED8 /* DeltaTests.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27AEFAC4210913C500106ED8 /* DeltaTests.cc */; };
 		27AEFAC921091A8C00106ED8 /* diff_match_patch.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27AEFAC721091A8C00106ED8 /* diff_match_patch.hh */; };
-		27B802D720DD750E00599DF0 /* NodeRef.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27B802D520DD750E00599DF0 /* NodeRef.cc */; };
-		27B802D820DD750E00599DF0 /* NodeRef.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27B802D620DD750E00599DF0 /* NodeRef.hh */; };
 		27C4ACAC1CE5146500938365 /* Array.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27C4ACAA1CE5146500938365 /* Array.cc */; };
 		27C4ACAD1CE5146500938365 /* Array.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C4ACAB1CE5146500938365 /* Array.hh */; };
 		27C4CEA92127722300470DE9 /* libfleeceStatic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 270FA25C1BF53CAD005DCB13 /* libfleeceStatic.a */; };
@@ -108,11 +102,8 @@
 		27C4CEBA2127976900470DE9 /* betterassert.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27C4CEB82127976900470DE9 /* betterassert.cc */; };
 		27C4CEBB2127976900470DE9 /* betterassert.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C4CEB92127976900470DE9 /* betterassert.hh */; };
 		27C59BA4212F898F003C8492 /* SmallVector.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C59BA2212F898F003C8492 /* SmallVector.hh */; };
-		27C8DF072084102900A99BFC /* MutableHashTree.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C8DF052084102900A99BFC /* MutableHashTree.hh */; };
-		27C8DF082084102900A99BFC /* MutableHashTree.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27C8DF062084102900A99BFC /* MutableHashTree.cc */; };
 		27CA08421F6B0E9400FF8C71 /* Dict.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27CA08401F6B0E9400FF8C71 /* Dict.hh */; };
 		27CA08431F6B0E9400FF8C71 /* Dict.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27CA08411F6B0E9400FF8C71 /* Dict.cc */; };
-		27CEE41A20EFE92E00089A85 /* KeyTree.cc in Sources */ = {isa = PBXBuildFile; fileRef = 278163BA1CE7A72300B94E32 /* KeyTree.cc */; };
 		27D5771A212B3032002410BA /* Bitmap.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27D57719212B3032002410BA /* Bitmap.cc */; };
 		27D7215E1F8E8EEA00AA4458 /* MDict+ObjC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2734B89D1F8583FF00BE5249 /* MDict+ObjC.mm */; };
 		27D721651F8E8EEA00AA4458 /* MValue+ObjC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 27D721201F8C04F100AA4458 /* MValue+ObjC.mm */; };
@@ -123,7 +114,6 @@
 		27D721741F8E8EEA00AA4458 /* CatchHelper.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27E3DD4B1DB6C32400F2872D /* CatchHelper.hh */; };
 		27D721751F8E8EEA00AA4458 /* MDict.hh in Headers */ = {isa = PBXBuildFile; fileRef = 2734B89C1F8583FF00BE5249 /* MDict.hh */; };
 		27D721761F8E8EEA00AA4458 /* FleeceDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 2734B8AB1F859AEC00BE5249 /* FleeceDocument.h */; };
-		27D721771F8E8EEA00AA4458 /* KeyTree.hh in Headers */ = {isa = PBXBuildFile; fileRef = 278163BB1CE7A72300B94E32 /* KeyTree.hh */; };
 		27D721781F8E8EEA00AA4458 /* Array.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C4ACAB1CE5146500938365 /* Array.hh */; };
 		27D721791F8E8EEA00AA4458 /* MArray.hh in Headers */ = {isa = PBXBuildFile; fileRef = 2734B8951F8583FF00BE5249 /* MArray.hh */; };
 		27D7217A1F8E8EEA00AA4458 /* Dict.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27CA08401F6B0E9400FF8C71 /* Dict.hh */; };
@@ -161,19 +151,16 @@
 		27DE2EB92125FA1700123597 /* MDict.hh in Headers */ = {isa = PBXBuildFile; fileRef = 2734B89C1F8583FF00BE5249 /* MDict.hh */; };
 		27DE2EBA2125FA1700123597 /* FleeceDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 2734B8AB1F859AEC00BE5249 /* FleeceDocument.h */; };
 		27DE2EBB2125FA1700123597 /* sliceIO.hh in Headers */ = {isa = PBXBuildFile; fileRef = 2776AA772093C982004ACE85 /* sliceIO.hh */; };
-		27DE2EBC2125FA1700123597 /* KeyTree.hh in Headers */ = {isa = PBXBuildFile; fileRef = 278163BB1CE7A72300B94E32 /* KeyTree.hh */; };
 		27DE2EBD2125FA1700123597 /* Array.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C4ACAB1CE5146500938365 /* Array.hh */; };
 		27DE2EBE2125FA1700123597 /* DeepIterator.hh in Headers */ = {isa = PBXBuildFile; fileRef = 2776AA20208678AA004ACE85 /* DeepIterator.hh */; };
 		27DE2EBF2125FA1700123597 /* MArray.hh in Headers */ = {isa = PBXBuildFile; fileRef = 2734B8951F8583FF00BE5249 /* MArray.hh */; };
 		27DE2EC02125FA1700123597 /* Dict.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27CA08401F6B0E9400FF8C71 /* Dict.hh */; };
 		27DE2EC12125FA1700123597 /* StringTable.hh in Headers */ = {isa = PBXBuildFile; fileRef = 2797BCAB1C0FBFDE00E5C991 /* StringTable.hh */; };
 		27DE2EC22125FA1700123597 /* JSONEncoder.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27FE87F21E53E43200C5CF3F /* JSONEncoder.hh */; };
-		27DE2EC32125FA1700123597 /* NodeRef.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27B802D620DD750E00599DF0 /* NodeRef.hh */; };
 		27DE2EC42125FA1700123597 /* TempArray.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27F666462017FE7C00A8ED31 /* TempArray.hh */; };
 		27DE2EC52125FA1700123597 /* Doc.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27867AF1211E27E5007BDA5F /* Doc.hh */; };
 		27DE2EC62125FA1700123597 /* MArray+ObjC.h in Headers */ = {isa = PBXBuildFile; fileRef = 2734B8971F8583FF00BE5249 /* MArray+ObjC.h */; };
 		27DE2EC72125FA1700123597 /* varint.hh in Headers */ = {isa = PBXBuildFile; fileRef = 270FA2771BF53CEA005DCB13 /* varint.hh */; };
-		27DE2EC82125FA1700123597 /* HashTree.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277F45AE208E871000A0D159 /* HashTree.hh */; };
 		27DE2EC92125FA1700123597 /* MValue.hh in Headers */ = {isa = PBXBuildFile; fileRef = 2734B8961F8583FF00BE5249 /* MValue.hh */; };
 		27DE2ECA2125FA1700123597 /* Value.hh in Headers */ = {isa = PBXBuildFile; fileRef = 270FA26B1BF53CEA005DCB13 /* Value.hh */; };
 		27DE2ECB2125FA1700123597 /* Endian.hh in Headers */ = {isa = PBXBuildFile; fileRef = 270FA2731BF53CEA005DCB13 /* Endian.hh */; };
@@ -186,7 +173,6 @@
 		27DE2ED32125FA1700123597 /* CaseListReporter.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27E3DD4A1DB6C32400F2872D /* CaseListReporter.hh */; };
 		27DE2ED42125FA1700123597 /* Writer.hh in Headers */ = {isa = PBXBuildFile; fileRef = 270FA2721BF53CEA005DCB13 /* Writer.hh */; };
 		27DE2ED52125FA1700123597 /* Encoder.hh in Headers */ = {isa = PBXBuildFile; fileRef = 270FA26F1BF53CEA005DCB13 /* Encoder.hh */; };
-		27DE2ED62125FA1700123597 /* MutableHashTree.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C8DF052084102900A99BFC /* MutableHashTree.hh */; };
 		27DE2ED72125FA1700123597 /* Path.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27A924CE1D9C32E800086206 /* Path.hh */; };
 		27DE2ED82125FA1700123597 /* HeapDict.hh in Headers */ = {isa = PBXBuildFile; fileRef = 274D8243209A3A77008BB39F /* HeapDict.hh */; };
 		27DE2ED92125FA1700123597 /* HeapValue.hh in Headers */ = {isa = PBXBuildFile; fileRef = 274D8251209CF9B3008BB39F /* HeapValue.hh */; };
@@ -403,21 +389,16 @@
 		2776AA47208A6C5A004ACE85 /* XcodeWarnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = XcodeWarnings.xcconfig; sourceTree = "<group>"; };
 		2776AA48208A6CED004ACE85 /* FleeceStaticLib.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FleeceStaticLib.xcconfig; sourceTree = "<group>"; };
 		2776AA49208A6E01004ACE85 /* FleeceTest.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FleeceTest.xcconfig; sourceTree = "<group>"; };
-		2776AA702090EF05004ACE85 /* HashTree+Internal.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = "HashTree+Internal.hh"; sourceTree = "<group>"; };
 		2776AA762093C982004ACE85 /* sliceIO.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = sliceIO.cc; sourceTree = "<group>"; };
 		2776AA772093C982004ACE85 /* sliceIO.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = sliceIO.hh; sourceTree = "<group>"; };
 		2779BA0E24CB4A4900BCEA8F /* ConcurrentMap.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ConcurrentMap.hh; sourceTree = "<group>"; };
 		2779BA0F24CB4A4900BCEA8F /* ConcurrentMap.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ConcurrentMap.cc; sourceTree = "<group>"; };
 		277A06B120B36D1A00970354 /* FileUtils.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FileUtils.cc; sourceTree = "<group>"; };
 		277A06B220B36D1A00970354 /* FileUtils.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = FileUtils.hh; sourceTree = "<group>"; };
-		277F45AE208E871000A0D159 /* HashTree.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = HashTree.hh; sourceTree = "<group>"; };
-		277F45AF208E871000A0D159 /* HashTree.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = HashTree.cc; sourceTree = "<group>"; };
 		277F45B3208E9A9100A0D159 /* Bitmap.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Bitmap.hh; sourceTree = "<group>"; };
 		278163B31CE69CA800B94E32 /* Fleece.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Fleece.cc; sourceTree = "<group>"; };
 		278163B71CE6A07A00B94E32 /* FleeceImpl.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = FleeceImpl.hh; sourceTree = "<group>"; };
 		278163B81CE6BB8C00B94E32 /* C_Test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = C_Test.c; sourceTree = "<group>"; };
-		278163BA1CE7A72300B94E32 /* KeyTree.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KeyTree.cc; sourceTree = "<group>"; };
-		278163BB1CE7A72300B94E32 /* KeyTree.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = KeyTree.hh; sourceTree = "<group>"; };
 		278343122A675A7000621050 /* function_ref.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = function_ref.hh; sourceTree = "<group>"; };
 		27867AF0211E27E5007BDA5F /* Doc.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Doc.cc; sourceTree = "<group>"; };
 		27867AF1211E27E5007BDA5F /* Doc.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Doc.hh; sourceTree = "<group>"; };
@@ -437,9 +418,6 @@
 		27AEFAC121090FF400106ED8 /* JSONDelta.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = JSONDelta.hh; sourceTree = "<group>"; };
 		27AEFAC4210913C500106ED8 /* DeltaTests.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DeltaTests.cc; sourceTree = "<group>"; };
 		27AEFAC721091A8C00106ED8 /* diff_match_patch.hh */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.cpp.h; path = diff_match_patch.hh; sourceTree = "<group>"; };
-		27B802D520DD750E00599DF0 /* NodeRef.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NodeRef.cc; sourceTree = "<group>"; };
-		27B802D620DD750E00599DF0 /* NodeRef.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NodeRef.hh; sourceTree = "<group>"; };
-		27B802D920DD762A00599DF0 /* MutableNode.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = MutableNode.hh; sourceTree = "<group>"; };
 		27C4AC941CDE843F00938365 /* Example.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = Example.md; sourceTree = "<group>"; };
 		27C4AC961CDFFDA100938365 /* Performance.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = Performance.md; sourceTree = "<group>"; };
 		27C4ACAA1CE5146500938365 /* Array.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Array.cc; sourceTree = "<group>"; };
@@ -453,9 +431,6 @@
 		27C4CEB82127976900470DE9 /* betterassert.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = betterassert.cc; sourceTree = "<group>"; };
 		27C4CEB92127976900470DE9 /* betterassert.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = betterassert.hh; sourceTree = "<group>"; };
 		27C59BA2212F898F003C8492 /* SmallVector.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = SmallVector.hh; sourceTree = "<group>"; };
-		27C8DF052084102900A99BFC /* MutableHashTree.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = MutableHashTree.hh; sourceTree = "<group>"; };
-		27C8DF062084102900A99BFC /* MutableHashTree.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MutableHashTree.cc; sourceTree = "<group>"; };
-		27C8DF09208521B600A99BFC /* HashTreeTests.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = HashTreeTests.cc; sourceTree = "<group>"; };
 		27CA08401F6B0E9400FF8C71 /* Dict.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Dict.hh; sourceTree = "<group>"; };
 		27CA08411F6B0E9400FF8C71 /* Dict.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Dict.cc; sourceTree = "<group>"; };
 		27CD12BB23DA3CCA00A7333C /* endianness.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = endianness.h; sourceTree = "<group>"; };
@@ -595,9 +570,7 @@
 				2734B8941F8583FF00BE5249 /* Integration */,
 				27A89D7C209FC44500C3BEB2 /* Mutable */,
 				27E3DD2A1DB1C17900F2872D /* ObjC */,
-				277F45B2208E9A6700A0D159 /* Tree */,
 				27AFF69720EFE6CE0055E966 /* Support */,
-				27CEE41B20EFE97100089A85 /* Experimental */,
 			);
 			path = Fleece;
 			sourceTree = "<group>";
@@ -688,7 +661,6 @@
 				27D96572233AB44000F4A51C /* NumericTests.cc */,
 				272E5A5E1BF91DBE00848580 /* ObjCTests.mm */,
 				27AEFAC4210913C500106ED8 /* DeltaTests.cc */,
-				27C8DF09208521B600A99BFC /* HashTreeTests.cc */,
 				271507F6212349B8005FE6E8 /* API_ValueTests.cc */,
 				278163B81CE6BB8C00B94E32 /* C_Test.c */,
 				27EC8D5B1CEBA72E00199FE6 /* mn_wordlist.h */,
@@ -758,21 +730,6 @@
 			);
 			name = xcconfigs;
 			path = Xcode/xcconfigs;
-			sourceTree = "<group>";
-		};
-		277F45B2208E9A6700A0D159 /* Tree */ = {
-			isa = PBXGroup;
-			children = (
-				277F45AF208E871000A0D159 /* HashTree.cc */,
-				277F45AE208E871000A0D159 /* HashTree.hh */,
-				2776AA702090EF05004ACE85 /* HashTree+Internal.hh */,
-				27C8DF062084102900A99BFC /* MutableHashTree.cc */,
-				27C8DF052084102900A99BFC /* MutableHashTree.hh */,
-				27B802D520DD750E00599DF0 /* NodeRef.cc */,
-				27B802D620DD750E00599DF0 /* NodeRef.hh */,
-				27B802D920DD762A00599DF0 /* MutableNode.hh */,
-			);
-			path = Tree;
 			sourceTree = "<group>";
 		};
 		279AC5321C096872002C80DB /* Tool */ = {
@@ -877,15 +834,6 @@
 			);
 			path = Support;
 			sourceTree = "<group>";
-		};
-		27CEE41B20EFE97100089A85 /* Experimental */ = {
-			isa = PBXGroup;
-			children = (
-				278163BA1CE7A72300B94E32 /* KeyTree.cc */,
-				278163BB1CE7A72300B94E32 /* KeyTree.hh */,
-			);
-			path = Experimental;
-			sourceTree = SOURCE_ROOT;
 		};
 		27CEE41C20EFEBB600089A85 /* Core */ = {
 			isa = PBXGroup;
@@ -997,7 +945,6 @@
 				2734B8A51F8583FF00BE5249 /* MDict.hh in Headers */,
 				2734B8AD1F859AEC00BE5249 /* FleeceDocument.h in Headers */,
 				2776AA792093C982004ACE85 /* sliceIO.hh in Headers */,
-				278163BD1CE7A72300B94E32 /* KeyTree.hh in Headers */,
 				27E3CE0F263B1B0700CA7056 /* Builder.hh in Headers */,
 				27C4ACAD1CE5146500938365 /* Array.hh in Headers */,
 				2776AA22208678AA004ACE85 /* DeepIterator.hh in Headers */,
@@ -1005,12 +952,10 @@
 				27CA08421F6B0E9400FF8C71 /* Dict.hh in Headers */,
 				2797BCAD1C0FBFDE00E5C991 /* StringTable.hh in Headers */,
 				27FE87F41E53E43200C5CF3F /* JSONEncoder.hh in Headers */,
-				27B802D820DD750E00599DF0 /* NodeRef.hh in Headers */,
 				27F666472017FE7C00A8ED31 /* TempArray.hh in Headers */,
 				27867AF3211E27E5007BDA5F /* Doc.hh in Headers */,
 				2734B8A01F8583FF00BE5249 /* MArray+ObjC.h in Headers */,
 				270FA2851BF53CEA005DCB13 /* varint.hh in Headers */,
-				277F45B0208E871000A0D159 /* HashTree.hh in Headers */,
 				2734B89F1F8583FF00BE5249 /* MValue.hh in Headers */,
 				27C4CEBB2127976900470DE9 /* betterassert.hh in Headers */,
 				270FA2791BF53CEA005DCB13 /* Value.hh in Headers */,
@@ -1026,7 +971,6 @@
 				278343132A675A7000621050 /* function_ref.hh in Headers */,
 				270FA2801BF53CEA005DCB13 /* Writer.hh in Headers */,
 				270FA27D1BF53CEA005DCB13 /* Encoder.hh in Headers */,
-				27C8DF072084102900A99BFC /* MutableHashTree.hh in Headers */,
 				27A924D01D9C32E800086206 /* Path.hh in Headers */,
 				274D8245209A3A77008BB39F /* HeapDict.hh in Headers */,
 				274D8253209CF9B3008BB39F /* HeapValue.hh in Headers */,
@@ -1051,7 +995,6 @@
 				27D721741F8E8EEA00AA4458 /* CatchHelper.hh in Headers */,
 				27D721751F8E8EEA00AA4458 /* MDict.hh in Headers */,
 				27D721761F8E8EEA00AA4458 /* FleeceDocument.h in Headers */,
-				27D721771F8E8EEA00AA4458 /* KeyTree.hh in Headers */,
 				27D721781F8E8EEA00AA4458 /* Array.hh in Headers */,
 				27D721791F8E8EEA00AA4458 /* MArray.hh in Headers */,
 				27D7217A1F8E8EEA00AA4458 /* Dict.hh in Headers */,
@@ -1088,7 +1031,6 @@
 				27DE2EBA2125FA1700123597 /* FleeceDocument.h in Headers */,
 				27DE2EBB2125FA1700123597 /* sliceIO.hh in Headers */,
 				2700BB9C217E8C0D00797537 /* ParseDate.hh in Headers */,
-				27DE2EBC2125FA1700123597 /* KeyTree.hh in Headers */,
 				27DE2EBD2125FA1700123597 /* Array.hh in Headers */,
 				27DE2EBE2125FA1700123597 /* DeepIterator.hh in Headers */,
 				27DE2EBF2125FA1700123597 /* MArray.hh in Headers */,
@@ -1099,13 +1041,11 @@
 				27DE2EC02125FA1700123597 /* Dict.hh in Headers */,
 				27DE2EC12125FA1700123597 /* StringTable.hh in Headers */,
 				27DE2EC22125FA1700123597 /* JSONEncoder.hh in Headers */,
-				27DE2EC32125FA1700123597 /* NodeRef.hh in Headers */,
 				27DE2EC42125FA1700123597 /* TempArray.hh in Headers */,
 				27DE2EC52125FA1700123597 /* Doc.hh in Headers */,
 				27DFAE12219F83AB00DF57EB /* InstanceCounted.hh in Headers */,
 				27DE2EC62125FA1700123597 /* MArray+ObjC.h in Headers */,
 				27DE2EC72125FA1700123597 /* varint.hh in Headers */,
-				27DE2EC82125FA1700123597 /* HashTree.hh in Headers */,
 				27DE2EC92125FA1700123597 /* MValue.hh in Headers */,
 				27DE2ECA2125FA1700123597 /* Value.hh in Headers */,
 				27DE2ECB2125FA1700123597 /* Endian.hh in Headers */,
@@ -1120,7 +1060,6 @@
 				2739971725CDBD8E000C1C1B /* SmallVectorBase.hh in Headers */,
 				27DE2ED42125FA1700123597 /* Writer.hh in Headers */,
 				27DE2ED52125FA1700123597 /* Encoder.hh in Headers */,
-				27DE2ED62125FA1700123597 /* MutableHashTree.hh in Headers */,
 				27C59BA4212F898F003C8492 /* SmallVector.hh in Headers */,
 				27DE2ED72125FA1700123597 /* Path.hh in Headers */,
 				27DE2ED82125FA1700123597 /* HeapDict.hh in Headers */,
@@ -1328,8 +1267,6 @@
 			files = (
 				27C4CEBA2127976900470DE9 /* betterassert.cc in Sources */,
 				270FA27E1BF53CEA005DCB13 /* Encoder+ObjC.mm in Sources */,
-				27C8DF082084102900A99BFC /* MutableHashTree.cc in Sources */,
-				277F45B1208E871000A0D159 /* HashTree.cc in Sources */,
 				270FA27B1BF53CEA005DCB13 /* Value+ObjC.mm in Sources */,
 				27C4ACAC1CE5146500938365 /* Array.cc in Sources */,
 				277A06B320B36D1A00970354 /* FileUtils.cc in Sources */,
@@ -1354,7 +1291,6 @@
 				27298E3C1C00F812000CFBA8 /* JSONConverter.cc in Sources */,
 				279AC53C1C097941002C80DB /* Value+Dump.cc in Sources */,
 				27FE87F31E53E43200C5CF3F /* JSONEncoder.cc in Sources */,
-				27B802D720DD750E00599DF0 /* NodeRef.cc in Sources */,
 				2797BCAC1C0FBFDE00E5C991 /* StringTable.cc in Sources */,
 				274D8248209A5906008BB39F /* ValueSlot.cc in Sources */,
 				274D8252209CF9B3008BB39F /* HeapValue.cc in Sources */,
@@ -1386,8 +1322,6 @@
 				2734B8A71F85842300BE5249 /* MTests.mm in Sources */,
 				272E5A5F1BF91DBE00848580 /* ObjCTests.mm in Sources */,
 				27E3CE12263B525E00CA7056 /* BuilderTests.cc in Sources */,
-				277F45B4208FDA1800A0D159 /* HashTreeTests.cc in Sources */,
-				27CEE41A20EFE92E00089A85 /* KeyTree.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Fleece/API_Impl/FLSlice.cc
+++ b/Fleece/API_Impl/FLSlice.cc
@@ -89,7 +89,7 @@ namespace fleece {
 #else
     static constexpr size_t kHeapAlignmentMask = 0x07;
 #endif
-    LITECORE_UNUSED FLPURE static inline bool isHeapAligned(const void *p) {
+    [[maybe_unused]] FLPURE static inline bool isHeapAligned(const void *p) {
         return ((size_t)p & kHeapAlignmentMask) == 0;
     }
 

--- a/Fleece/API_Impl/Fleece+ImplGlue.hh
+++ b/Fleece/API_Impl/Fleece+ImplGlue.hh
@@ -20,26 +20,22 @@
 #include "FleeceException.hh"
 #include <memory>
 
-using namespace fleece;
-using namespace fleece::impl;
-
-
-namespace fleece { namespace impl {
+namespace fleece:: impl {
     struct FLEncoderImpl;
-} }
+}
 
 // Define the public types as typedefs of the impl types:
-typedef const Value*    FLValue;
-typedef const Array*    FLArray;
-typedef const Dict*     FLDict;
-typedef ValueSlot*      FLSlot;
-typedef MutableArray*   FLMutableArray;
-typedef MutableDict*    FLMutableDict;
-typedef FLEncoderImpl*  FLEncoder;
-typedef SharedKeys*     FLSharedKeys;
-typedef Path*           FLKeyPath;
-typedef DeepIterator*   FLDeepIterator;
-typedef const Doc*      FLDoc;
+typedef const fleece::impl::Value*    FLValue;
+typedef const fleece::impl::Array*    FLArray;
+typedef const fleece::impl::Dict*     FLDict;
+typedef fleece::impl::ValueSlot*      FLSlot;
+typedef fleece::impl::MutableArray*   FLMutableArray;
+typedef fleece::impl::MutableDict*    FLMutableDict;
+typedef fleece::impl::FLEncoderImpl*  FLEncoder;
+typedef fleece::impl::SharedKeys*     FLSharedKeys;
+typedef fleece::impl::Path*           FLKeyPath;
+typedef fleece::impl::DeepIterator*   FLDeepIterator;
+typedef const fleece::impl::Doc*      FLDoc;
 
 #define FL_IMPL         // Prevents redefinition of the above types
 

--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -33,6 +33,9 @@ namespace fleece::impl {
 
 }
 
+using namespace fleece;
+using namespace fleece::impl;
+
 
 FLEECE_PUBLIC const FLValue kFLNullValue  = Value::kNullValue;
 FLEECE_PUBLIC const FLValue kFLUndefinedValue  = Value::kUndefinedValue;

--- a/Fleece/Core/Builder.cc
+++ b/Fleece/Core/Builder.cc
@@ -83,7 +83,7 @@ namespace fleece::impl::builder {
     protected:
         // Parses a Fleece value from the input and stores it in the ValueSlot.
         // Recognizes a '%' specifier, and calls `putParameter` to read the value from the args.
-        const bool _buildValue(ValueSlot &inSlot) {
+        bool _buildValue(ValueSlot &inSlot) {
             switch (peekToken()) {
                 case '[': {
                     Retained<MutableArray> array = MutableArray::newArray();

--- a/Fleece/Core/Encoder.hh
+++ b/Fleece/Core/Encoder.hh
@@ -169,7 +169,7 @@ namespace fleece { namespace impl {
         size_t nextWritePos();
         size_t finishItem();
         slice base() const                      {return _base;}
-        slice baseUsed() const                  {return _baseMinUsed != 0 ? slice(_baseMinUsed, _base.end()) : slice();}
+        slice baseUsed() const                  {return _baseMinUsed ? slice(_baseMinUsed, _base.end()) : slice();}
         const StringTable& strings() const      {return _strings;}
 
         enum class PreWrittenValue : intptr_t { none = INTPTR_MIN };
@@ -250,8 +250,8 @@ namespace fleece { namespace impl {
         Retained<SharedKeys> _sharedKeys;  // Client-provided key-to-int mapping
         slice _base;                 // Base Fleece data being appended to (if any)
         alloc_slice _ownedBase;      // If I allocated _base, it's stored here too to retain it
-        const void* _baseCutoff {0}; // Lowest addr in _base that I can write a ptr to
-        const void* _baseMinUsed {0};// Lowest addr in _base I've written a ptr to
+        const void* _baseCutoff {};  // Lowest addr in _base that I can write a ptr to
+        const void* _baseMinUsed {}; // Lowest addr in _base I've written a ptr to
         int _copyingCollection {0};  // Nonzero inside writeValue when writing array/dict
         bool _writingKey    {false}; // True if Value being written is a key
         bool _blockedOnKey  {false}; // True if writes should be refused

--- a/Fleece/Core/JSONConverter.cc
+++ b/Fleece/Core/JSONConverter.cc
@@ -12,8 +12,13 @@
 
 #include "JSONConverter.hh"
 #include "NumConversion.hh"
-#include "jsonsl.h"
 #include <map>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#include "jsonsl.h"
+#pragma clang diagnostic pop
 
 namespace fleece { namespace impl {
 

--- a/Fleece/Core/JSONDelta.cc
+++ b/Fleece/Core/JSONDelta.cc
@@ -17,11 +17,17 @@
 #include "JSON5.hh"
 #include "FleeceException.hh"
 #include "TempArray.hh"
-#include "diff_match_patch.hh"
 #include "NumConversion.hh"
 #include <sstream>
 #include <unordered_set>
 #include "betterassert.hh"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdouble-promotion"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#include "diff_match_patch.hh"
+#pragma clang diagnostic pop
 
 
 namespace fleece { namespace impl {
@@ -30,6 +36,7 @@ namespace fleece { namespace impl {
 
     // Set this to true to create deltas compatible with JsonDiffPatch.
     // (this is really just here for test purposes so we can use the JDP unit test dataset...)
+    extern bool gCompatibleDeltas;
     bool gCompatibleDeltas = false;
 
     size_t JSONDelta::gMinStringDiffLength = 60;

--- a/Fleece/Core/Value.hh
+++ b/Fleece/Core/Value.hh
@@ -267,7 +267,7 @@ namespace fleece { namespace impl {
     NOINLINE void assignRef(const Value* &holder, const Value *newValue) noexcept;
 
     template <typename T>
-    static inline void assignRef(T* &holder, const Value *newValue) noexcept {
+    inline void assignRef(T* &holder, const Value *newValue) noexcept {
         assignRef((const Value*&)holder, newValue);
     }
 

--- a/Fleece/Core/Value.hh
+++ b/Fleece/Core/Value.hh
@@ -121,7 +121,7 @@ namespace fleece { namespace impl {
         /** Returns the exact contents of a binary data value. Other types return a null slice. */
         slice asData() const noexcept FLPURE;
 
-        typedef int64_t FLTimestamp;
+        using FLTimestamp = int64_t;
         #define FLTimestampNone INT64_MIN
 
         /** Converts a value to a timestamp, in milliseconds since Unix epoch, or INT64_MIN on failure.
@@ -259,6 +259,16 @@ namespace fleece { namespace impl {
         friend class ValueDumper;
         template <bool WIDE> friend struct dictImpl;
     };
+
+    // explicit template instantiations
+    extern template float Value::asFloatOfType<float>() const noexcept;
+    extern template double Value::asFloatOfType<double>() const noexcept;
+    extern template void Value::toJSON<1>(Writer&) const;
+    extern template void Value::toJSON<5>(Writer&) const;
+    extern template alloc_slice Value::toJSON<1>(bool canonical) const;
+    extern template alloc_slice Value::toJSON<5>(bool canonical) const;
+    extern template const Value* Value::deref<false>() const;
+    extern template const Value* Value::deref<true>() const;
 
 
     // Some glue needed to make RefCounted<Value> work (see RefCounted.hh)

--- a/Fleece/Mutable/HeapValue.cc
+++ b/Fleece/Mutable/HeapValue.cc
@@ -80,11 +80,6 @@ namespace fleece { namespace impl { namespace internal {
         }
     }
 
-    template HeapValue* HeapValue::createInt<int>(int i, bool isUnsigned);
-    template HeapValue* HeapValue::createInt<unsigned>(unsigned i, bool isUnsigned);
-    template HeapValue* HeapValue::createInt<int64_t>(int64_t i, bool isUnsigned);
-    template HeapValue* HeapValue::createInt<uint64_t>(uint64_t i, bool isUnsigned);
-
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/Fleece/Mutable/HeapValue.hh
+++ b/Fleece/Mutable/HeapValue.hh
@@ -74,6 +74,10 @@ namespace fleece { namespace impl {
             template <class INT> static HeapValue* createInt(INT, bool isUnsigned);
         };
 
+        extern template HeapValue* HeapValue::createInt(int,      bool isUnsigned);
+        extern template HeapValue* HeapValue::createInt(unsigned, bool isUnsigned);
+        extern template HeapValue* HeapValue::createInt(int64_t,  bool isUnsigned);
+        extern template HeapValue* HeapValue::createInt(uint64_t, bool isUnsigned);
 
 
         /** Abstract base class of Heap{Array,Dict}. */

--- a/Fleece/Support/Bitmap.hh
+++ b/Fleece/Support/Bitmap.hh
@@ -88,7 +88,4 @@ namespace fleece {
     /** Utility function for constructing a Bitmap from an integer. */
     template <class Rep>
     inline Bitmap<Rep> asBitmap(Rep bits)     {return Bitmap<Rep>(bits);}
-
-    template <class Rep>
-    constexpr unsigned Bitmap<Rep>::capacity;
 }

--- a/Fleece/Support/JSON5.cc
+++ b/Fleece/Support/JSON5.cc
@@ -231,7 +231,7 @@ namespace fleece {
         }
 
         // Throws an exception.
-        void fail(const char *error) {
+        [[noreturn]] void fail(const char *error) {
             stringstream message;
             message << error << " (at :" << _pos << ")";
             throw json5_error(message.str(), _pos);

--- a/Fleece/Support/JSONEncoder.hh
+++ b/Fleece/Support/JSONEncoder.hh
@@ -66,7 +66,7 @@ namespace fleece { namespace impl {
         void writeRaw(slice raw)                {_out << raw;}
 
 #ifdef __OBJC__
-        void writeObjC(id)                      {FleeceException::_throw(JSONError,
+        [[noreturn]] void writeObjC(id)         {FleeceException::_throw(JSONError,
                                                     "Encoding Obj-C to JSON is unimplemented");}
 #endif
 
@@ -102,7 +102,7 @@ namespace fleece { namespace impl {
         // Just for API compatibility with Encoder class:
         void beginArray(size_t)                       {beginArray();}
         void beginDictionary(size_t)                  {beginDictionary();}
-        void writeUndefined() {
+        [[noreturn]] void writeUndefined() {
             FleeceException::_throw(JSONError, "Cannot write `undefined` to JSON encoder");
         }
 

--- a/Fleece/Support/NumConversion.hh
+++ b/Fleece/Support/NumConversion.hh
@@ -42,7 +42,7 @@ namespace fleece {
     bool ParseInteger(const char *str NONNULL, uint64_t &result, bool allowTrailing =false);
 
     /// Alternative syntax for parsing an unsigned integer.
-    static inline bool ParseUnsignedInteger(const char *str NONNULL, uint64_t &r, bool t =false) {
+    inline bool ParseUnsignedInteger(const char *str NONNULL, uint64_t &r, bool t =false) {
         return ParseInteger(str, r, t);
     }
 
@@ -65,11 +65,11 @@ namespace fleece {
     size_t WriteFloat(float n, char *dst, size_t capacity);
 
     /// Alternative syntax for formatting a 64-bit-floating point number to a string.
-    static inline size_t WriteDouble(double n, char *dst, size_t c)  {return WriteFloat(n, dst, c);}
+    inline size_t WriteDouble(double n, char *dst, size_t c)  {return WriteFloat(n, dst, c);}
 
     #if DEBUG
         template<typename Out, typename In>
-        static Out narrow_cast (In val) {
+        Out narrow_cast (In val) {
             static_assert(::std::is_arithmetic<In>::value && ::std::is_arithmetic<Out>::value, "Only numeric types are valid for narrow_cast");
             if constexpr(sizeof(In) <= sizeof(Out) && ::std::is_signed<In>::value == ::std::is_signed<Out>::value) {
                 return (Out)val;
@@ -107,7 +107,7 @@ namespace fleece {
         }
     #else
         template<typename Out, typename In>
-        static inline Out narrow_cast(In val) {
+        inline Out narrow_cast(In val) {
             return static_cast<Out>(val);
         }
     #endif

--- a/Fleece/Support/slice_stream.hh
+++ b/Fleece/Support/slice_stream.hh
@@ -28,6 +28,8 @@ namespace fleece {
         /// \warning Like a `const_cast`, this violates the read-only nature of the slice.
         explicit slice_ostream(slice s)          :slice_ostream((uint8_t*)s.buf, s.size) { }
 
+        slice_ostream& operator=(const slice_ostream&) = default;
+
         /// Captures the stream's state to another stream. You can use this as a way to "rewind"
         /// the stream afterwards. (This is equivalent to a copy constructor, but that constructor
         /// is explicitly deleted to avoid confusion.)

--- a/ObjC/Encoder+ObjC.mm
+++ b/ObjC/Encoder+ObjC.mm
@@ -62,7 +62,7 @@ void FLSlot_SetCFValue(FLSlot slot, CFTypeRef value) {
 
 
 @implementation NSObject (Fleece)
-- (void) fl_encodeToFLEncoder: (FLEncoder)enc {
+- (void) fl_encodeToFLEncoder: (FLEncoder)enc __attribute__((noreturn)) {
     // Default implementation -- object doesn't implement Fleece encoding at all.
     NSString* msg = [NSString stringWithFormat: @"Objects of class %@ cannot be encoded",
                      [self class]];

--- a/ObjC/Fleece+CoreFoundation.mm
+++ b/ObjC/Fleece+CoreFoundation.mm
@@ -14,6 +14,8 @@
 #import "fleece/Fleece+CoreFoundation.h"
 #import <Foundation/Foundation.h>
 
+using namespace fleece;
+using namespace fleece::impl;
 
 NSString* const FLErrorDomain = @"Fleece";
 

--- a/Tests/API_ValueTests.cc
+++ b/Tests/API_ValueTests.cc
@@ -25,8 +25,9 @@ namespace fleece {
 #include "fleece/Fleece.hh"
 #include "fleece/Mutable.hh"
 
-using namespace fleece;
 using namespace std;
+using namespace fleece;
+using namespace fleece_test;
 
 
 #if 0

--- a/Tests/BuilderTests.cc
+++ b/Tests/BuilderTests.cc
@@ -24,6 +24,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
+using namespace fleece;
 using namespace fleece::impl;
 
 

--- a/Tests/DeltaTests.cc
+++ b/Tests/DeltaTests.cc
@@ -21,6 +21,7 @@ namespace fleece { namespace impl {
 
 using namespace fleece;
 using namespace fleece::impl;
+using namespace fleece_test;
 
 
 static bool isValidUTF8(fleece::slice sl) noexcept;
@@ -210,7 +211,7 @@ static void checkDelta(const Value *left, const Value *right, const Value *expec
     if (expectedDelta)
         CHECK(expectedDelta->isEqual(delta));
     else
-        CHECK(delta == 0);
+        CHECK(delta == nullptr);
 }
 
 

--- a/Tests/EncoderTests.cc
+++ b/Tests/EncoderTests.cc
@@ -1076,11 +1076,12 @@ public:
         CHECK(ParseDouble(floatBuf, recovered));
         CHECK(FloatEquals(float(recovered), 2.71828f));
 
+        const char* localeName = "fr_FR";
 #ifdef _MSC_VER
-        setlocale(LC_ALL, "fr-FR");
-#else
-        setlocale(LC_ALL, "fr_FR");
+        localeName = "fr-FR";
 #endif
+        if(setlocale(LC_ALL, localeName) == nullptr)
+            FAIL("Zut alors! No French locale installed!");
 
         snprintf(doubleBuf, doubleBufSize, "%.16g", testDouble);
         snprintf(floatBuf, floatBufSize, "%.7g", testFloat);

--- a/Tests/EncoderTests.cc
+++ b/Tests/EncoderTests.cc
@@ -13,11 +13,8 @@
 #include "FleeceTests.hh"
 #include "Pointer.hh"
 #include "JSONConverter.hh"
-#include "KeyTree.hh"
 #include "Path.hh"
 #include "Internal.hh"
-#include "jsonsl.h"
-#include "mn_wordlist.h"
 #include "NumConversion.hh"
 #include <iostream>
 #include "fleece/Fleece.hh"
@@ -27,8 +24,18 @@
 #include <unistd.h>
 #endif
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma clang diagnostic ignored "-Wdocumentation"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#include "jsonsl.h"
+#include "mn_wordlist.h"
+#pragma clang diagnostic pop
+
+
 namespace fleece { namespace impl {
     using namespace fleece::impl::internal;
+    using namespace fleece_test;
 
 class EncoderTests {
 public:
@@ -975,6 +982,7 @@ public:
 
 #pragma mark - KEY TREE:
 
+#if 0
     TEST_CASE_METHOD(EncoderTests, "KeyTree", "[Encoder]") {
         bool verbose = false;
 
@@ -1037,6 +1045,7 @@ public:
         REQUIRE(keys[(unsigned)n+28].buf == nullptr);
         REQUIRE(keys[(unsigned)9999].buf == nullptr);
     }
+#endif
 
     TEST_CASE("Locale-free encoding") {
         // Note this will fail if Linux is missing the French locale,
@@ -1113,7 +1122,7 @@ public:
         }
 
         constexpr const char* kFailCases[] = {
-            "", " ", "+", " +", " + ", "x", " x", "1234x", "1234 x", "123.456", "-17", " + 1234"
+            "", " ", "+", " +", " + ", "x", " x", "1234x", "1234 x", "123.456", "-17", " + 1234",
             "18446744073709551616" // UINT64_MAX + 1
         };
 

--- a/Tests/FleeceTests.cc
+++ b/Tests/FleeceTests.cc
@@ -34,6 +34,7 @@
 
 
 namespace fleece_test {
+    using namespace fleece;
 
     std::string sliceToHex(slice result) {
         std::string hex;

--- a/Tests/FleeceTests.hh
+++ b/Tests/FleeceTests.hh
@@ -29,7 +29,8 @@
     #define srandom srand
 #endif
 
-using namespace fleece;
+using slice = fleece::slice;
+using alloc_slice = fleece::alloc_slice;
 
 #if FL_HAVE_FILESYSTEM
     #ifdef _MSC_VER
@@ -84,12 +85,11 @@ namespace fleece_test {
     static inline std::string json5(const std::string &s)      {return fleece::ConvertJSON5(s);}
 }
 
-using namespace fleece_test;
 
 namespace fleece {
     // to make slice work with Catch's logging. This has to be in the 'fleece' namespace.
     static inline std::ostream& operator<< (std::ostream& o, slice s) {
-        return dumpSlice(o, s);
+        return fleece_test::dumpSlice(o, s);
     }
 
     static inline bool DoubleEquals(double left, double right) {

--- a/Tests/MutableTests.cc
+++ b/Tests/MutableTests.cc
@@ -20,6 +20,7 @@
 
 namespace fleece {
     using namespace fleece::impl;
+    using namespace fleece_test;
 
     TEST_CASE("MutableArray type checking", "[Mutable]") {
         Retained<MutableArray> ma = MutableArray::newArray();
@@ -33,7 +34,7 @@ namespace fleece {
         CHECK(ma->asBool() == true);
         CHECK(ma->asInt() == 0);
         CHECK(ma->asUnsigned() == 0);
-        CHECK(ma->asFloat() == 0.0);
+        CHECK(ma->asFloat() == 0.0f);
         CHECK(ma->asDouble() == 0.0);
 
         CHECK(!ma->isInteger());
@@ -314,7 +315,7 @@ namespace fleece {
         CHECK(d->asBool() == true);
         CHECK(d->asInt() == 0);
         CHECK(d->asUnsigned() == 0);
-        CHECK(d->asFloat() == 0.0);
+        CHECK(d->asFloat() == 0.0f);
         CHECK(d->asDouble() == 0.0);
 
         CHECK(!d->isInteger());

--- a/Tests/ObjCTests.mm
+++ b/Tests/ObjCTests.mm
@@ -14,6 +14,7 @@
 #include "FleeceTests.hh"
 #include "FleeceImpl.hh"
 
+using namespace fleece;
 using namespace fleece::impl;
 
 static void checkIt(id obj, const char* json) {
@@ -190,11 +191,9 @@ TEST_CASE("Obj-C PerfReadNamesNS", "[.Perf]") {
 
         Stopwatch st;
         for (int j = 0; j < 10000; j++) {
-            int i = 0;
             for (NSDictionary *person in people) {
                 if (person[@"name"] == nil)
                     abort();
-                i++;
             }
         }
         fprintf(stderr, "Iterating people (NS) took %g ms\n", st.elapsedMS()/10000);

--- a/Tests/PerfTests.cc
+++ b/Tests/PerfTests.cc
@@ -28,13 +28,6 @@
 #define REQUIRE(TEST)   while (!(TEST)) {abort();}
 #undef CHECK
 #define CHECK(TEST)     while (!(TEST)) {abort();}
-#ifdef __APPLE__
-#define FLEECE_UNUSED __unused
-#elif !defined(_MSC_VER)
-#define FLEECE_UNUSED __attribute__((unused))
-#else
-#define FLEECE_UNUSED
-#endif
 
 
 using namespace fleece;
@@ -116,7 +109,7 @@ TEST_CASE("Perf LoadFleece", "[.Perf]") {
         Benchmark bench;
         for (int i = 0; i < kIterations; i++) {
             bench.start();
-            FLEECE_UNUSED auto root = Value::fromData(doc)->asArray();
+            [[maybe_unused]] auto root = Value::fromData(doc)->asArray();
             REQUIRE(root != nullptr);
             bench.stop();
         }
@@ -130,7 +123,7 @@ TEST_CASE("Perf LoadFleece", "[.Perf]") {
         for (int i = 0; i < kIterations; i++) {
             bench.start();
             for (int j = 0; j < kIterationsPerSample; j++) {
-                FLEECE_UNUSED auto root = Value::fromTrustedData(doc)->asArray();
+                [[maybe_unused]] auto root = Value::fromTrustedData(doc)->asArray();
                 REQUIRE(root != nullptr);
             }
             bench.stop();

--- a/Tests/PerfTests.cc
+++ b/Tests/PerfTests.cc
@@ -23,6 +23,8 @@
 #endif
 #include "betterassert.hh"
 
+#pragma clang diagnostic ignored "-Wmissing-noreturn"
+
 // Catch's REQUIRE is too slow for perf testing
 #undef REQUIRE
 #define REQUIRE(TEST)   while (!(TEST)) {abort();}
@@ -32,6 +34,7 @@
 
 using namespace fleece;
 using namespace fleece::impl;
+using namespace fleece_test;
 
 
 #if !FL_EMBEDDED

--- a/Tests/SharedKeysTests.cc
+++ b/Tests/SharedKeysTests.cc
@@ -18,7 +18,9 @@
 #include <limits.h>
 
 using namespace std;
+using namespace fleece;
 using namespace fleece::impl;
+using namespace fleece_test;
 
 
 TEST_CASE("basic", "[SharedKeys]") {

--- a/Tests/SupportTests.cc
+++ b/Tests/SupportTests.cc
@@ -11,6 +11,7 @@
 //
 
 #include "fleece/FLBase.h"
+#include "fleece/InstanceCounted.hh"
 #include "FleeceTests.hh"
 #include "FleeceImpl.hh"
 #include "Backtrace.hh"
@@ -358,4 +359,22 @@ TEST_CASE("Backtrace") {
     string str = bt.toString();
     cout << str << endl;
     CHECK(std::count(str.begin(), str.end(), '\n') >= 4);
+}
+
+
+class ICTest : public RefCounted, public InstanceCountedIn<ICTest> {
+public:
+    ICTest() noexcept = default;
+};
+
+
+TEST_CASE("InstanceCounted") {
+    auto n = InstanceCounted::liveInstanceCount();
+    {
+        auto i1 = make_retained<ICTest>();
+        auto i2 = make_retained<ICTest>();
+        InstanceCounted::dumpInstances();
+        CHECK(InstanceCounted::liveInstanceCount() == n + 2);
+    }
+    CHECK(InstanceCounted::liveInstanceCount() == n);
 }

--- a/Tests/SupportTests.cc
+++ b/Tests/SupportTests.cc
@@ -23,6 +23,7 @@
 #include <future>
 
 using namespace std;
+using namespace fleece;
 
 
 // TESTS:

--- a/Tests/SupportTests.cc
+++ b/Tests/SupportTests.cc
@@ -346,6 +346,7 @@ TEST_CASE("Timestamp Conversions", "[Timestamps]") {
     FLStringResult str = FLTimestamp_ToString(ts, asUTC);
     FLTimestamp ts2 = FLTimestamp_FromString((FLString)str);
     CHECK(ts == ts2);
+    FLSliceResult_Release(str);
 }
 
 

--- a/Tests/ValueTests.cc
+++ b/Tests/ValueTests.cc
@@ -32,6 +32,7 @@ namespace fleece {
     using namespace std;
     using namespace impl;
     using namespace impl::internal;
+    using namespace fleece_test;
 
     class ValueTests {  // Value declares this as a friend so it can call private API
     public:
@@ -290,7 +291,7 @@ namespace fleece {
             fleece::ErrorCode errCode = fleece::NoError;
             try {
                 doc = Doc::fromJSON(origJSON);
-            } catch (FleeceException& exc) {
+            } catch (FleeceException&) {
                 errCode = fleece::JSONError;
             }
             CHECK(errCode == fleece::JSONError);

--- a/cmake/platform_base.cmake
+++ b/cmake/platform_base.cmake
@@ -47,9 +47,9 @@ function(set_source_files_base)
         Fleece/Support/StringTable.cc
         Fleece/Support/varint.cc
         Fleece/Support/Writer.cc
-        Fleece/Tree/HashTree.cc
-        Fleece/Tree/MutableHashTree.cc
-        Fleece/Tree/NodeRef.cc
+#        Fleece/Tree/HashTree.cc
+#        Fleece/Tree/MutableHashTree.cc
+#        Fleece/Tree/NodeRef.cc
         vendor/jsonsl/jsonsl.c
         vendor/libb64/cdecode.c
         vendor/libb64/cencode.c
@@ -73,7 +73,7 @@ function(set_test_source_files_base)
         Tests/FleeceTests.cc
         Tests/BuilderTests.cc
         Tests/FleeceTestsMain.cc
-        Tests/HashTreeTests.cc
+#       Tests/HashTreeTests.cc
         Tests/JSON5Tests.cc
         Tests/MutableTests.cc
         Tests/PerfTests.cc
@@ -81,7 +81,7 @@ function(set_test_source_files_base)
         Tests/SupportTests.cc
         Tests/ValueTests.cc
         Tests/C_Test.c
-        Experimental/KeyTree.cc
+#       Experimental/KeyTree.cc
         PARENT_SCOPE
     )
 endfunction()

--- a/vendor/SwiftDtoa/SwiftDtoa.cc
+++ b/vendor/SwiftDtoa/SwiftDtoa.cc
@@ -116,6 +116,10 @@
 
 #include "SwiftDtoa.h"                      //Jens: Edited path
 
+#pragma clang diagnostic ignored "-Wimplicit-int-conversion"    //Jens: Added this
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"           //Jens: Added this
+#pragma clang diagnostic ignored "-Wdouble-promotion"           //Jens: Added this
+
 namespace fleece {                          //Jens: Added namespace
 
 

--- a/vendor/date/include/date/date.h
+++ b/vendor/date/include/date/date.h
@@ -963,8 +963,8 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year_month_weekday_last&
 inline namespace literals
 {
 
-CONSTCD11 date::day  operator "" _d(unsigned long long d) NOEXCEPT;
-CONSTCD11 date::year operator "" _y(unsigned long long y) NOEXCEPT;
+CONSTCD11 date::day  operator ""_d(unsigned long long d) NOEXCEPT;
+CONSTCD11 date::year operator ""_y(unsigned long long y) NOEXCEPT;
 
 }  // inline namespace literals
 #endif // !defined(_MSC_VER) || (_MSC_VER >= 1900)
@@ -1972,7 +1972,7 @@ inline namespace literals
 CONSTCD11
 inline
 date::day
-operator "" _d(unsigned long long d) NOEXCEPT
+operator ""_d(unsigned long long d) NOEXCEPT
 {
     return date::day{static_cast<unsigned>(d)};
 }
@@ -1980,7 +1980,7 @@ operator "" _d(unsigned long long d) NOEXCEPT
 CONSTCD11
 inline
 date::year
-operator "" _y(unsigned long long y) NOEXCEPT
+operator ""_y(unsigned long long y) NOEXCEPT
 {
     return date::year(static_cast<int>(y));
 }


### PR DESCRIPTION
Added new CMake options: 

- `FLEECE_WARNINGS_HARDCORE` enables _all_ compiler warnings except for a few dozen that are too onerous, plus `-Werror`.
- `FLEECE_SANITIZE` enables the Clang Address and UB sanitizers.

Currently these are only supported in Clang builds, and ignored with other compilers.

Also made source changes to fix some of the newly-enabled warnings.