### PR TITLE
GitHub Actions: Added `concurrency`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,6 +18,11 @@ on:
     branches:
       - '**'
 
+concurrency:
+  # Cancel any running actions when a branch is updated:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug


### PR DESCRIPTION
Bit of boilerplate to cancel running actions when a branch is updated.

https://turso.tech/blog/simple-trick-to-save-environment-and-money-when-using-github-actions