### PR TITLE
slice: buf & size should not be initialized in their declaration

### DIFF
--- a/API/fleece/slice.hh
+++ b/API/fleece/slice.hh
@@ -104,8 +104,8 @@ namespace fleece {
           changes this.
         * The memory pointed to cannot be modified through this class. */
     struct pure_slice {
-        const void* FL_NULLABLE const buf  = nullptr;
-        size_t                  const size = 0;
+        const void* FL_NULLABLE const buf;
+        size_t                  const size;
 
         constexpr const void* data() const noexcept FLPURE          {return buf;}   //like std::span
         constexpr size_t size_bytes() const noexcept FLPURE         {return size;}  //like std::span
@@ -216,7 +216,7 @@ namespace fleece {
         inline slice copy() const;
 
     protected:
-        constexpr pure_slice() noexcept = default;
+        constexpr pure_slice() noexcept                             :buf(nullptr), size(0) {}
         inline constexpr pure_slice(const void* FL_NULLABLE b, size_t s) noexcept;
 
         inline void setBuf(const void *b) noexcept;


### PR DESCRIPTION
This reverts a problematic change made in October in commit 170d7170.

pure_slice's buf and size fields are, for historical reasons, public but read-only. The read-only nature is enforced by declaring them 'const'.

Recently while refactoring I moved the default values of those fields into the declaration, i.e. adding `= 0` and `= nullptr`. This is correct code, but it turned out to confuse some static analysis tools, which now assume that these fields will _always_ be 0 or NULL. As a result, in CLion I'm seeing IDE warning markers that some code is unreachable or some expressions are always true or always false. These are just noise, really, but they're annoying.

It's easy enough to fix this regression by taking out the initializers on the variable declarations and moving them back to the default constructor.