### PR TITLE
Avoid UBSan error iterating empty SmallVector

### DIFF
--- a/Fleece/Support/RefCounted.cc
+++ b/Fleece/Support/RefCounted.cc
@@ -48,10 +48,12 @@ namespace fleece {
     __cold static void fail(const RefCounted *obj, const char *what, int refCount,
                             bool andThrow =true)
     {
-        char *message;
-        asprintf(&message,
+        char *message = nullptr;
+        int n = asprintf(&message,
                  "RefCounted object <%s @ %p> %s while it had an invalid refCount of %d (0x%x)",
                  Unmangle(typeid(*obj)).c_str(), obj, what, refCount, refCount);
+        if (n < 0)
+            throw std::runtime_error("RefCounted object has an invalid refCount");
 #ifdef WarnError
         WarnError("%s", message);
 #else

--- a/Fleece/Support/SmallVector.hh
+++ b/Fleece/Support/SmallVector.hh
@@ -123,10 +123,10 @@ namespace fleece {
         using iterator = T*;
         using const_iterator = const T*;
 
-        iterator begin() LIFETIMEBOUND FLPURE                       {return &_get(0);}
-        iterator end() LIFETIMEBOUND FLPURE                         {return &_get(_size);}
-        const_iterator begin() const LIFETIMEBOUND FLPURE           {return &_get(0);}
-        const_iterator end() const LIFETIMEBOUND FLPURE             {return &_get(_size);}
+        iterator begin() LIFETIMEBOUND FLPURE                       {return (T*)_begin();}
+        iterator end() LIFETIMEBOUND FLPURE                         {return begin() + _size;}
+        const_iterator begin() const LIFETIMEBOUND FLPURE           {return (const T*)_begin();}
+        const_iterator end() const LIFETIMEBOUND FLPURE             {return begin() + _size;}
 
         T& push_back(const T& t) LIFETIMEBOUND                      {return * new(grow()) T(t);}
         T& push_back(T&& t) LIFETIMEBOUND                           {return * new(grow()) T(std::move(t));}


### PR DESCRIPTION
Iterating an empty smallVector triggers a UBSan warning about "forming a reference to nullptr".

`_get()` returns a reference to the first item; when the vector is empty the first item could point to nullptr. So avoid using `_get` in `begin()` / `end()`, which just take the address of the reference anyway. Calling `_begin()` instead is simpler.

A second commit snuck in :) that just resolves a GCC warning about ignoring the return value of `asprintf`.