### PR TITLE
fix calling base class private method

### DIFF
--- a/API/fleece/InstanceCounted.hh
+++ b/API/fleece/InstanceCounted.hh
@@ -48,9 +48,9 @@ namespace fleece {
 
     protected:
         InstanceCounted(size_t offset)              {track(offset);}
+        void untrack() const;
     private:
         void track(size_t offset =0) const;
-        void untrack() const;
         static void dumpInstances(function_ref<void(const InstanceCounted*)>*);
 
 #else


### PR DESCRIPTION
because of bugs gcc/clang accept this before,
but now clang 19.x gives compile time error,
because of "untack" method is private:

https://godbolt.org/z/hd9n1o3br