### PR TITLE
Fixed FLEECE_PUBLIC to avoid GCC attribute warnings

### DIFF
--- a/API/fleece/CompilerSupport.h
+++ b/API/fleece/CompilerSupport.h
@@ -259,13 +259,19 @@
 // implementation) with FLEECE_PUBLIC.  See kFLNullValue below and in Fleece.cc
 // for an example.
 #if defined(_MSC_VER)
-#ifdef FLEECE_EXPORTS
-#define FLEECE_PUBLIC __declspec(dllexport)
+#   ifdef FLEECE_EXPORTS
+#       define FLEECE_PUBLIC __declspec(dllexport)
+#   else
+#       define FLEECE_PUBLIC __declspec(dllimport)
+#   endif
+#   define FLEECE_PUBLIC_IMPL FLEECE_PUBLIC
 #else
-#define FLEECE_PUBLIC __declspec(dllimport)
-#endif
-#else
-#define FLEECE_PUBLIC __attribute__((visibility("default")))
+#   define FLEECE_PUBLIC __attribute__((visibility("default")))
+#   ifdef __clang__
+#       define FLEECE_PUBLIC_IMPL FLEECE_PUBLIC
+#   else
+#       define FLEECE_PUBLIC_IMPL
+#   endif
 #endif
 
 #ifdef __cplusplus

--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -37,10 +37,10 @@ using namespace fleece;
 using namespace fleece::impl;
 
 
-FLEECE_PUBLIC const FLValue kFLNullValue  = Value::kNullValue;
-FLEECE_PUBLIC const FLValue kFLUndefinedValue  = Value::kUndefinedValue;
-FLEECE_PUBLIC const FLArray kFLEmptyArray = Array::kEmpty;
-FLEECE_PUBLIC const FLDict kFLEmptyDict   = Dict::kEmpty;
+FLEECE_PUBLIC_IMPL const FLValue kFLNullValue  = Value::kNullValue;
+FLEECE_PUBLIC_IMPL const FLValue kFLUndefinedValue  = Value::kUndefinedValue;
+FLEECE_PUBLIC_IMPL const FLArray kFLEmptyArray = Array::kEmpty;
+FLEECE_PUBLIC_IMPL const FLDict kFLEmptyDict   = Dict::kEmpty;
 
 
 FLTimestamp FLTimestamp_Now() FLAPI {


### PR DESCRIPTION
From now on use FLEECE_PUBLIC_IMPL on the implementations of symbols.

See also https://github.com/couchbase/couchbase-lite-core/pull/2258