### PR TITLE
Improvements from the P2P work

### DIFF
--- a/API/fleece/RefCounted.hh
+++ b/API/fleece/RefCounted.hh
@@ -274,6 +274,13 @@ namespace fleece {
     }
 
 
+    /** `retained_cast<T>(...)` is like `dynamic_cast` but on pointers wrapped in Retained. */
+    template <class T, class U>
+    Retained<T> retained_cast(Retained<U> const& r) {
+        return dynamic_cast<T*>(r.get());
+    }
+
+
     /** Extracts the pointer from a Retained. It must later be released via `release`.
         This is used in bridging functions that return a direct pointer for a C API. */
     template <typename REFCOUNTED>

--- a/API/fleece/slice.hh
+++ b/API/fleece/slice.hh
@@ -261,7 +261,7 @@ namespace fleece {
         slice& operator= (const char* s) & noexcept           {return *this = slice(s);}
         slice& operator= (alloc_slice&&) =delete;   // Disallowed: might lead to ptr to freed buf
         slice& operator= (std::string&&) =delete;   // Disallowed: might lead to ptr to freed buf
-        slice& operator= (const alloc_slice &s LIFETIMEBOUND) & noexcept    {return *this = slice(s);}
+        inline slice& operator= (const alloc_slice &s LIFETIMEBOUND) & noexcept;
         slice& operator= (std::nullptr_t) & noexcept          {set(nullptr, 0); return *this;}
         inline slice& operator= (nullslice_t) & noexcept;
 
@@ -355,6 +355,8 @@ namespace fleece {
             std::swap((slice&)*this, (slice&)s);
             return *this;
         }
+
+        operator FLSlice() const noexcept LIFETIMEBOUND STEPOVER {return FLSlice{buf, size};}
 
         /** Creates an alloc_slice that has an extra null (0) byte immediately after the end of the
             data. This allows the contents of the alloc_slice to be used as a C string. */
@@ -733,6 +735,12 @@ namespace fleece {
 
     inline slice& slice::operator= (nullslice_t) & noexcept {
         set(nullptr, 0);
+        return *this;
+    }
+
+
+    slice& slice::operator= (alloc_slice const& s) & noexcept {
+        set(s.buf, s.size);
         return *this;
     }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ if(FLEECE_WARNINGS_HARDCORE)
             -Wno-switch-default # "'switch' missing 'default' label"
             -Wno-switch-enum
             -Wno-undef      # `#if X` where X isn't defined
+            -Wno-unknown-warning-option # So older Clang doesn't barf on newer warnings listed here :(
             -Wno-unused-macros
             -Wno-unused-parameter # Unused fn parameter
             -Wno-weak-vtables # "Class has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit"

--- a/Fleece/Support/RefCounted.cc
+++ b/Fleece/Support/RefCounted.cc
@@ -34,7 +34,7 @@ namespace fleece {
         if (r) r->_release();
     }
 
-    
+
     __hot void assignRef(RefCounted* &holder, RefCounted *newValue) noexcept {
         RefCounted *oldValue = holder;
         if (_usuallyTrue(newValue != oldValue)) {
@@ -68,7 +68,7 @@ namespace fleece {
     }
 
 
-    RefCounted::~RefCounted() {
+    RefCounted::~RefCounted() noexcept {
         // Store a garbage value to detect use-after-free
         int32_t oldRef = _refCount.exchange(-9999999);
         if (_usuallyFalse(oldRef != 0)) {
@@ -123,5 +123,13 @@ namespace fleece {
         // If the refCount just went to 0, delete the object:
         if (oldRef == 1) delete this;
     }
+
+
+    // Called by Retained<>. Broken out so it's not duplicated in each instantiaton of the template.
+    __cold void _failNullRef() {
+        throw std::invalid_argument("storing nullptr in a non-nullable Retained");
+    }
+
+
 
 }

--- a/Fleece/Support/SmallVector.hh
+++ b/Fleece/Support/SmallVector.hh
@@ -120,6 +120,11 @@ namespace fleece {
         const T& back() const LIFETIMEBOUND FLPURE                  {return get(_size - 1);}
         T& back() LIFETIMEBOUND FLPURE                              {return get(_size - 1);}
 
+        /// True if the vector contains an item equal to `item`.
+        bool contains(T const& item) const FLPURE {
+            return std::find(begin(), end(), item) != end();
+        }
+
         using iterator = T*;
         using const_iterator = const T*;
 
@@ -152,6 +157,24 @@ namespace fleece {
             T *dst = (T*)_insert(where, uint32_t(n), kItemSize);
             while (b != e)
                 *dst++ = *b++;
+        }
+
+        /// Appends an item if an equal item isn't already present; else returns false.
+        bool addUnique(T const& item) {
+            if (!contains(item)) {
+                push_back(item);
+                return true;
+            }
+            return false;
+        }
+
+        /// Removes an item equal to `item`; else returns false.
+        bool remove(T const& item) {
+            if (auto j = std::find(begin(), end(), item); j != end()) {
+                erase(j);
+                return true;
+            }
+            return false;
         }
 
         iterator erase(iterator first) LIFETIMEBOUND {

--- a/Fleece/Support/slice_stream.hh
+++ b/Fleece/Support/slice_stream.hh
@@ -134,11 +134,8 @@ namespace fleece {
     /** A simple stream that reads from memory using a slice to keep track of the available bytes. */
     struct slice_istream : public slice {
         // slice_istream is constructed from a slice, or from the same parameters as a slice.
-        constexpr slice_istream(const slice &s) noexcept        :slice(s) { }
-        slice_istream(const alloc_slice &s) noexcept  :slice(s) { }
-        constexpr slice_istream(const void* b, size_t s) noexcept STEPOVER    :slice(b, s) {}
-        constexpr slice_istream(const void* s NONNULL, const void* e NONNULL) noexcept STEPOVER
-                                                                      :slice(s, e) { }
+        using slice::slice;
+        constexpr slice_istream(pure_slice s) noexcept          :slice(s.buf, s.size) { }
         constexpr slice_istream(slice_istream&&) = default;
         slice_istream& operator=(slice_istream&&) = default;
 


### PR DESCRIPTION
Best to look at each of the 5 commits individually:

### [smallVector: added contains, addUnique, remove](https://github.com/couchbase/fleece/pull/262/commits/378abaa0d63bcedbbe995f7b0895043f07ec6d53)

Simply adds three utility methods. These are useful for using a smallVector as a lightweight set (for small sizes obviously.)

### [RefCounted: Added retained_cast](https://github.com/couchbase/fleece/pull/262/commits/3d1ed61e3744ceb4a4cb0d9c726d6f578a02e2ec)

`retained_cast<T>(U)` is equivalent to `dynamic_cast` except its parameter and result are Retained values not raw pointers.

### [CMake: Added -Wno-unknown-warning-option](https://github.com/couchbase/fleece/pull/262/commits/d2ad82b96583ef3dde185b73ca26a36e1310ec09)

Fixes a build error in Clang 16. [I've actually made this a separate PR, #263, since it's broken the master branch.]

### [slice: Improved use of LIFETIMEBOUND](https://github.com/couchbase/fleece/pull/262/commits/8cfd106abdc1ee6d167d0cd2b535a0541b5e360f)

Helps detect some additional dangling-pointer errors, by adding the LIFETIMEBOUND attribute for conversions from alloc_slice to slice. This tells Clang that the resulting slice's lifetime must not exceed the original alloc_slice's.

There are some other changes that are just to fix some annoying compiler errors triggered by the above.

### [RefCounted: Added non-nullable Retained, AKA Ref](https://github.com/couchbase/fleece/pull/262/commits/fae3f3e1c115d69ec8c6e9369e0a2be0cde4ed0d)

OK, this one is cool! I added a second template parameter to `Retained` so it can be nullable or non-nullable; it's now `Retained<class T, Nullability N>`. The second parameter defaults to `MaybeNull` so normal use of Retained works as before, but now we also have `Retained<T,Nonnull>` -- aliased as `Ref<T>`.

`Ref<T>` is just like `Retained<T>` except it cannot hold nullptr.
- It's very useful in API function parameters as an indication that null isn't legal; and in return values as a promise that the result is never null.
- It has no default constructor; it has to be constructed with a value.
- Its methods use FL_NONNULL so UBSan will detect violations at runtime (and sometimes at compile time.)
- Even without UBSan, putting a null pointer in one causes a failure (NPE) at runtime.
- You can't directly convert a Retained<T> to a Ref<T>; you have to call `asRef()`, which throws illegal_argument if the value is null. (I couldn't think of a better name for this. Something like "IPromiseThisIsNotNull".)
- Ref<T> is able to skip most null checks when calling retain() and release(), making the code slightly smaller & faster.

As a side benefit, I found that the `RetainedConst` class was never necessary; `RetainedConst<T>` is equivalent to `Retained<const T>`.