### PR TITLE
CMake: Added -Wno-unknown-warning-option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ if(FLEECE_WARNINGS_HARDCORE)
             -Wno-switch-default # "'switch' missing 'default' label"
             -Wno-switch-enum
             -Wno-undef      # `#if X` where X isn't defined
+            -Wno-unknown-warning-option # So older Clang doesn't barf on newer warnings listed here :(
             -Wno-unused-macros
             -Wno-unused-parameter # Unused fn parameter
             -Wno-weak-vtables # "Class has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit"


### PR DESCRIPTION
Fixes build breakage from commit 39838ac3e68e38579553f012d5101f62714960f3.

`-Wmissing-designated-field-initializers` was added in Clang 17, so turning it off in CMakeLists.txt triggers an "unknown warning option" warning from earlier versions of Clang. Notably this breaks the build in versions of Xcode prior to 16.3 (and CMake builds using this version of the Xcode CLI tools.)