### PR TITLE
Fixed Xcode 26 / Clang 17 build errors

### DIFF
--- a/API/fleece/RefCounted.hh
+++ b/API/fleece/RefCounted.hh
@@ -14,6 +14,7 @@
 #include "fleece/PlatformCompat.hh"
 #include <atomic>
 #include <concepts>
+#include <cstddef>
 #include <stdexcept>
 #include <utility>
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ if(FLEECE_WARNINGS_HARDCORE)
             -Wno-objc-messaging-id
             -Wno-old-style-cast
             -Wno-padded # "padding size of X with N bytes to alignment boundary"
+            -Wno-reserved-identifier
+            -Wno-reserved-macro-identifier
             -Wno-sign-conversion
             -Wno-suggest-destructor-override # "'~Foo' overrides a destructor but is not marked 'override'"
             -Wno-super-class-method-mismatch # Obj-C "method parameter type does not match super class method parameter type"


### PR DESCRIPTION
- RefCounted.hh needs to include the header that defines `std::nullptr_t`
- Disabled new warnings that complain about identifiers or macros beginning with an underscore

PR https://github.com/couchbase/couchbase-lite-core/pull/2351 depends on this one.